### PR TITLE
[12.0][IMP] account_credit_control use partner email

### DIFF
--- a/account_credit_control/wizard/credit_control_communication.py
+++ b/account_credit_control/wizard/credit_control_communication.py
@@ -102,7 +102,10 @@ class CreditControlCommunication(models.TransientModel):
         """ Return a valid email for customer """
         self.ensure_one()
         contact = self.contact_address
-        return contact.email
+        email = contact.email
+        if not email and contact.commercial_partner_id.email:
+            email = contact.commercial_partner_id.email
+        return email
 
     @api.multi
     @api.returns('res.partner')


### PR DESCRIPTION
when no any email avaible on invoice contract use
parent email if exists

port https://github.com/OCA/account-financial-tools/pull/879