### PR TITLE
[12.0][ENH] Credit Control Report Odoo 12 style

### DIFF
--- a/account_credit_control/report/report_credit_control_summary.xml
+++ b/account_credit_control/report/report_credit_control_summary.xml
@@ -2,23 +2,22 @@
 <odoo>
     <template id="report_credit_control_summary_document">
         <t t-call="web.external_layout">
-            <t t-set="doc" t-value="doc.with_context({'lang':doc.partner_id.lang})" />
+            <t t-set="doc" t-value="doc.with_context({'lang':doc.partner_id.lang})"/>
+            <t t-set="address">
+                <address t-field="doc.contact_address" t-options="{'widget':'contact', 'fields': ['address', 'name'], 'no_marker': True}"/>
+            </t>
             <div class="page">
-                <div class="row" id="address">
-                    <div class="col-xs-5 col-xs-offset-7">
-                        <address t-field="doc.contact_address"
-                                 t-options='{"widget": "contact",
-                                             "fields": ["address", "name"],
-                                             "no_marker": true}'/>
-                    </div>
-                    <div class="col-xs-5 col-xs-offset-7">
-                        <span t-field="doc.report_date"/>
-                    </div>
-                </div>
 
                 <h2 id="policy_level">
                     <span t-field="doc.current_policy_level.name"/>
                 </h2>
+
+                <div id="informations" class="row mt32 mb32">
+                  <div class="col-auto mw-100 mb-2" name="date">
+                    <strong>Date:</strong>
+                    <p class="m-0" t-field="doc.report_date"/>
+                  </div>
+                </div>
 
                 <div class="row mt32 mb32">
                     <div class="col-xs-12">
@@ -61,7 +60,7 @@
                             </td>
 
                             <td class="text-right">
-                                <span t-field="l.amount_due" t-options='{"widget": "monetary", "display_currency": l.currency_id or l.company_id.currency_id}'/>
+                                <span t-field="l.amount_due" t-options="{'widget': 'monetary', 'display_currency': l.currency_id or l.company_id.currency_id}"/>
                             </td>
                             <td class="text-right">
                                 <span t-field="l.balance_due" t-options="{'widget': 'monetary', 'display_currency': l.currency_id or l.company_id.currency_id}"/>
@@ -71,7 +70,7 @@
                 </table>
 
                 <div class="row">
-                    <div class="col-xs-4 pull-right">
+                    <div t-attf-class="#{'col-4' if report_type != 'html' else 'col-sm-7 col-md-5'} ml-auto">
                         <table class="table table-condensed">
                             <tr>
                                 <td>


### PR DESCRIPTION
Go closer to the default Odoo 12 report style used in invoice document report.
The aim is to have a better harmonization between reports.
That PR also fixes the total table not going on right when printing.