### PR TITLE
[12.0] [ADD] Always compute option on Policy Level

### DIFF
--- a/account_credit_control/models/credit_control_line.py
+++ b/account_credit_control/models/credit_control_line.py
@@ -225,12 +225,10 @@ class CreditControlLine(models.Model):
             line = self.create([vals])
             new_lines |= line
 
-            # when we have lines generated earlier in draft,
-            # on the same level, it means that we have left
-            # them, so they are to be considered as ignored
+            # other lines still in draft for this move_line
+            # have to be ignored
             previous_drafts = self.search([
                 ('move_line_id', '=', move_line.id),
-                ('policy_level_id', '=', level.id),
                 ('state', '=', 'draft'),
                 ('id', '!=', line.id),
             ])

--- a/account_credit_control/models/credit_control_run.py
+++ b/account_credit_control/models/credit_control_run.py
@@ -140,6 +140,7 @@ class CreditControlRun(models.Model):
                 create = policy_lines_generated.create_or_update_from_mv_lines
                 for level in reversed(policy.level_ids):
                     level_lines = level.get_level_lines(self.date, lines)
+                    lines -= level_lines
                     policy_lines_generated += create(
                         level_lines, level, self.date)
             generated |= policy_lines_generated

--- a/account_credit_control/readme/CONFIGURE.rst
+++ b/account_credit_control/readme/CONFIGURE.rst
@@ -1,7 +1,10 @@
 Configure the policies and policy levels in ``Invoicing  > Configuration >
 Credit Control > Credit Control Policies``.
-You can define as many policy levels as you need. You must set on which
-accounts are applied every Credit Control Policy under Accounts tab.
+You can define as many policy levels as you need. Marking a policy level
+'Always Compute' will make possible to generate lines of this level
+without going through lower levels.
+You must set on which accounts are applied every Credit Control Policy
+under Accounts tab.
 
 Configure a tolerance for the Credit control and a default policy
 applied on all partners in each company, under the Accounting tab in your

--- a/account_credit_control/tests/test_credit_control_policy.py
+++ b/account_credit_control/tests/test_credit_control_policy.py
@@ -50,6 +50,15 @@ class TestCreditControlPolicy(TransactionCase):
         with self.assertRaises(ValidationError):
             level_1.computation_mode = 'previous_date'
 
+    def test_check_always_compute(self):
+        """
+        Check the method _check_always_compute on policy level
+        """
+        level_3 = self.env.ref('account_credit_control.3_time_3')
+
+        with self.assertRaises(ValidationError):
+            level_3.always_compute = True
+
     def test_previous_level(self):
         """
         Check the method _previous_level on policy level

--- a/account_credit_control/views/credit_control_policy.xml
+++ b/account_credit_control/views/credit_control_policy.xml
@@ -20,6 +20,7 @@
                                 <field name="channel"/>
                                 <field name="delay_days"/>
                                 <field name="computation_mode"/>
+                                <field name="always_compute"/>
                                 <field name="email_template_id"/>
                             </tree>
                             <form string="Policy level">
@@ -31,6 +32,7 @@
                                             <field name="channel"/>
                                             <field name="delay_days"/>
                                             <field name="computation_mode"/>
+                                            <field name="always_compute"/>
                                         </group>
                                     </page>
                                     <page string="Mail and reporting">
@@ -106,6 +108,7 @@
                             <field name="channel"/>
                             <field name="delay_days"/>
                             <field name="computation_mode"/>
+                            <field name="always_compute"/>
                         </group>
                     </page>
                     <page string="Mail and reporting">
@@ -129,6 +132,7 @@
                 <field name="channel"/>
                 <field name="delay_days"/>
                 <field name="computation_mode"/>
+                <field name="always_compute"/>
                 <field name="email_template_id"/>
             </tree>
         </field>


### PR DESCRIPTION
Add an option on Policy Level to generate lines of this level even if lower level lines have not be generated or are still in draft. Thus, for instance, a credit control line of level 3 might be generated from a line of level 1, bypassing 2, because conditions of the 3rd level are met.

Use Case: Our customer considers that even if he forgets to process the credit control line and send the reminder to his customer, if his customer is very late higher level reminder should be send rather than lower one.