### PR TITLE
[12.0] [REF] Move Credit Control related fields on res.partner to a dedicated page

### DIFF
--- a/account_credit_control/views/res_partner.xml
+++ b/account_credit_control/views/res_partner.xml
@@ -26,22 +26,24 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="groups_id" eval="[(4, ref('account_credit_control.group_account_credit_control_manager')), (4, ref('account_credit_control.group_account_credit_control_user'))]"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='accounting_entries']" position="after">
-                <group string="Follow-up" name="followup">
-                    <field name="credit_policy_id" widget="selection"/>
-                    <field name="payment_responsible_id"/>
-                    <field name="payment_note"/>
-                    <field name="payment_next_action"/>
-                    <field name="payment_next_action_date"/>
-                    <field name="credit_control_analysis_ids" nolabel="1" colspan="2">
-                        <tree editable="bottom">
-                            <field name="policy_id"/>
-                            <field name="policy_level_id"/>
-                            <field name="level"/>
-                        </tree>
-                    </field>
-                </group>
-            </xpath>
+            <page name="accounting" position="after">
+                <page string="Credit Control" name="credit_control" attrs="{'invisible': [('is_company','=',False),('parent_id','!=',False)]}" groups="account.group_account_invoice">
+                    <group string="Follow-up" name="followup">
+                        <field name="credit_policy_id" widget="selection"/>
+                        <field name="payment_responsible_id"/>
+                        <field name="payment_note"/>
+                        <field name="payment_next_action"/>
+                        <field name="payment_next_action_date"/>
+                        <field name="credit_control_analysis_ids" nolabel="1" colspan="2">
+                            <tree editable="bottom">
+                                <field name="policy_id"/>
+                                <field name="policy_level_id"/>
+                                <field name="level"/>
+                            </tree>
+                        </field>
+                    </group>
+                </page>
+            </page>
         </field>
     </record>
 

--- a/account_credit_control/views/res_partner.xml
+++ b/account_credit_control/views/res_partner.xml
@@ -28,7 +28,7 @@
         <field name="arch" type="xml">
             <page name="accounting" position="after">
                 <page string="Credit Control" name="credit_control" attrs="{'invisible': [('is_company','=',False),('parent_id','!=',False)]}" groups="account.group_account_invoice">
-                    <group string="Follow-up" name="followup">
+                    <group name="followup">
                         <field name="credit_policy_id" widget="selection"/>
                         <field name="payment_responsible_id"/>
                         <field name="payment_note"/>


### PR DESCRIPTION
With several modules installed, the 'Invoicing' page on partners may get big.
Moreover, credit control related data often are relevant to more than accountants (e.g. salesperson, prod, etc.).
This split aims to lighten the 'Invoicing' page and ease the access rights management.

![image](https://user-images.githubusercontent.com/43472442/67080093-c9868180-f194-11e9-9d9c-544e7d797e48.png)