### PR TITLE
[12.0][FIX] account_credit_control: Children model policy lines should be deleted on cascade

### DIFF
--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -218,6 +218,7 @@ class CreditControlPolicyLevel(models.Model):
         comodel_name='credit.control.policy',
         string='Related Policy',
         required=True,
+        ondelete="cascade",
     )
     level = fields.Integer(
         required=True,


### PR DESCRIPTION
cc @Tecnativa TT20468