### PR TITLE
[12.0][FIX] account_financial_risk: consider sign in financial risk draft invoices

### DIFF
--- a/account_financial_risk/README.rst
+++ b/account_financial_risk/README.rst
@@ -87,6 +87,10 @@ Contributors
 
 * Agathe Mollé <agathe.molle@savoirfairelinux.com>
 
+* `RGB Consulting <https://www.rgbconsulting.com>`_:
+
+  * Domantas Sidorenkovas
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/account_financial_risk/__manifest__.py
+++ b/account_financial_risk/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Account Financial Risk',
     'summary': 'Manage customer risk',
-    'version': '12.0.1.1.1',
+    'version': '12.0.1.2.1',
     'category': 'Accounting',
     'license': 'AGPL-3',
     'author': 'Tecnativa, Odoo Community Association (OCA)',

--- a/account_financial_risk/models/res_partner.py
+++ b/account_financial_risk/models/res_partner.py
@@ -115,9 +115,9 @@ class ResPartner(models.Model):
     @api.multi
     @api.depends(
         'customer', 'invoice_ids', 'invoice_ids.state',
-        'invoice_ids.amount_total',
+        'invoice_ids.amount_total_signed',
         'child_ids.invoice_ids', 'child_ids.invoice_ids.state',
-        'child_ids.invoice_ids.amount_total')
+        'child_ids.invoice_ids.amount_total_signed')
     def _compute_risk_invoice(self):
         all_partners_and_children = {}
         all_partner_ids = []
@@ -133,11 +133,11 @@ class ResPartner(models.Model):
             [('type', 'in', ['out_invoice', 'out_refund']),
              ('state', 'in', ['draft', 'proforma', 'proforma2']),
              ('partner_id', 'in', self.ids)],
-            ['partner_id', 'amount_total'],
+            ['partner_id', 'amount_total_signed'],
             ['partner_id'])
         for partner, child_ids in list(all_partners_and_children.items()):
             partner.risk_invoice_draft = sum(
-                x['amount_total']
+                x['amount_total_signed']
                 for x in total_group if x['partner_id'][0] in child_ids)
 
     @api.model


### PR DESCRIPTION
**Description of the issue this PR addresses**
Refund invoices in draft state are not considered as negative amounts in the customer's financial risk fields.

**Steps to reproduce:**
- Create a  new customer.
- Create a refund invoice (credit note) for the customer.
- Go to the customer's financial risk tab.

**Current behavior before PR:**
- The amount of draft invoices is positive.

**Desired behavior after PR is merged:**
- The amount of draft invoices is negative.
