### PR TITLE
[11.0][FIX] sale_financial_risk: Right customer's financial risk sale order and invoices fields

### DIFF
--- a/sale_financial_risk/README.rst
+++ b/sale_financial_risk/README.rst
@@ -70,6 +70,7 @@ Contributors
   * Pedro M. Baeza
 
 * Agathe Mollé <agathe.molle@savoirfairelinux.com>
+* Rodrigo Bonilla <rodrigo.bonilla@factorlibre.com.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_financial_risk/README.rst
+++ b/sale_financial_risk/README.rst
@@ -70,7 +70,7 @@ Contributors
   * Pedro M. Baeza
 
 * Agathe Mollé <agathe.molle@savoirfairelinux.com>
-* Rodrigo Bonilla <rodrigo.bonilla@factorlibre.com.com>
+* Rodrigo Bonilla <rodrigo.bonilla@factorlibre.com>
 
 Maintainers
 ~~~~~~~~~~~


### PR DESCRIPTION
Description of the issue that this PR focus on.
Sale order and invoices in draft state sum the same at the customer's financial risk sale order  and invoices fields.

Steps to double the process:

Create a new customer.
Create a sale order and confirm it and validate stock picking.
Create invoice of the sale order.

Current behavior before PR:
The calculation of sale order and invoice in draft state is the same that the customer's financial risk fields.

Desired behavior after PR is merged:
The customer's financial risk sale order field should´t indicate the sum of the sale order.