### PR TITLE
account_credit_control: Fix potential TypeError

### DIFF
--- a/account_credit_control/wizard/credit_control_communication.py
+++ b/account_credit_control/wizard/credit_control_communication.py
@@ -202,7 +202,7 @@ class CreditControlCommunication(models.TransientModel):
             email_values.pop('model', None)
             email_values.pop('res_id', None)
             # Remove when mail.template returns correct format attachments
-            attachment_list = email_values.pop('attachments', None)
+            attachment_list = email_values.pop('attachments', [])
             email = emails.create(email_values)
 
             state = 'sent'


### PR DESCRIPTION
`email_values` might not contain `attachments` element
In such case, `attachment_list` variable becomes `None`
This leads to an error on line 227:
"TypeError: 'NoneType' object is not iterable"