### PR TITLE
[IMP] account_financial_risk: Avoid compute all partners saving config settings

### DIFF
--- a/account_financial_risk/models/res_company.py
+++ b/account_financial_risk/models/res_company.py
@@ -13,3 +13,12 @@ class ResCompany(models.Model):
              "The change of this field recompute all partners risk,"
              "be patient.",
     )
+
+    # TODO: Remove when odoo compare values before to write
+    def write(self, vals):
+        new_margin = vals.get('invoice_unpaid_margin')
+        if (new_margin is not None and
+                all(new_margin == x.invoice_unpaid_margin for x in self)):
+            vals = vals.copy()
+            vals.pop('invoice_unpaid_margin')
+        return super().write(vals)


### PR DESCRIPTION
This module adds a field in config settings, this field is allways saved when we click save button even we are in other section and we don't change any option.

With this PR I try avoid this trigger if don't change the value:
https://github.com/OCA/credit-control/blob/bf46dd5d299106973381858c731ab9a3d255d301/account_financial_risk/models/res_partner.py#L166

@Tecnativa TT22541