### PR TITLE
[FIX] Remove isort seed

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -9,4 +9,4 @@ line_length=88
 known_odoo=odoo
 known_odoo_addons=odoo.addons
 sections=FUTURE,STDLIB,THIRDPARTY,ODOO,ODOO_ADDONS,FIRSTPARTY,LOCALFOLDER
-known_third_party=setuptools
+default_section=THIRDPARTY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,12 +51,8 @@ repos:
   rev: v1.24.0
   hooks:
   - id: pyupgrade
-- repo: https://github.com/asottile/seed-isort-config
-  rev: v1.9.3
-  hooks:
-  - id: seed-isort-config
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+- repo: https://github.com/timothycrosley/isort
+  rev: 4.3.21-2
   hooks:
   - id: isort
     name: isort except __init__.py


### PR DESCRIPTION
This is a test implementation of the hypothesis explained in https://github.com/OCA/maintainer-quality-tools/pull/629#issuecomment-588131706, which aims to avoid unnecessary and constant git conflicts in `.isort.cfg` file.