### PR TITLE
[12.0][FIX] sale_financial_risk: Duplicate amount on risk_sale_order and risk_invoice_draft

### DIFF
--- a/sale_financial_risk/models/sale.py
+++ b/sale_financial_risk/models/sale.py
@@ -68,7 +68,7 @@ class SaleOrderLine(models.Model):
         """
         for line in self.filtered(lambda l: l.state == 'sale'):
             invoice_lines = line.invoice_lines.filtered(
-                lambda l: l.invoice_id.state in {'open', 'in_payment', 'paid'})
+                lambda l: l.invoice_id.state != 'cancel')
             amount_invoiced = 0.0
             for inv_line in invoice_lines:
                 inv_date = (inv_line.invoice_id.date_invoice


### PR DESCRIPTION
### Before PR:

Confirmed SO/001 with total amount 100€:
risk_sale_order = 100€
risk_invoice_draft = 0
risk_invoice_open = 0

After create a draft invoice from SO/001:
**risk_sale_order = 100€
risk_invoice_draft = 100€**
risk_invoice_open = 0


### After this PR:

Confirmed SO/001 with total amount 100€:
risk_sale_order = 100€
risk_invoice_draft = 0
risk_invoice_open = 0

After create a draft invoice from SO/001:
**risk_sale_order = 0€
risk_invoice_draft = 100€**
risk_invoice_open = 0


@Tecnativa