### PR TITLE
[IMP] Report custom text fields in html

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -3,7 +3,7 @@
 # Copyright 2018 Access Bookings Ltd (https://accessbookings.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Account Credit Control',
- 'version': '12.0.1.6.0',
+ 'version': '12.0.1.7.0',
  'author': "Camptocamp,"
            "Odoo Community Association (OCA),"
            "Okia,"

--- a/account_credit_control/migrations/12.0.1.7.0/post-migration.py
+++ b/account_credit_control/migrations/12.0.1.7.0/post-migration.py
@@ -1,0 +1,30 @@
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    Convert custom_text fields to Html on policy_level
+    """
+    cr = env.cr
+    openupgrade.copy_columns(
+        cr,
+        {
+            "credit_control_policy_level": [
+                ("custom_text", None, None),
+                ("custom_text_after_details", None, None),
+            ]
+        },
+    )
+    openupgrade.convert_field_to_html(
+        cr, "credit_control_policy_level", "custom_text", "custom_text"
+    )
+    openupgrade.convert_field_to_html(
+        cr,
+        "credit_control_policy_level",
+        "custom_text_after_details",
+        "custom_text_after_details",
+    )

--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -279,7 +279,7 @@ class CreditControlPolicyLevel(models.Model):
         selection=CHANNEL_LIST,
         required=True,
     )
-    custom_text = fields.Text(
+    custom_text = fields.Html(
         string='Custom Message',
         required=True,
         translate=True,
@@ -289,7 +289,7 @@ class CreditControlPolicyLevel(models.Model):
         required=True,
         translate=True,
     )
-    custom_text_after_details = fields.Text(
+    custom_text_after_details = fields.Html(
         string='Custom Message after details',
         translate=True,
     )


### PR DESCRIPTION
The aim of these two fields is to be injected in reports, thus it seems more convenient to me to have them in HTML.