### PR TITLE
[11.0][IMP] Add selection: choose which currency should be used in risk

### DIFF
--- a/account_financial_risk/__init__.py
+++ b/account_financial_risk/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizards
+from .hooks import pre_init_hook

--- a/account_financial_risk/__manifest__.py
+++ b/account_financial_risk/__manifest__.py
@@ -21,4 +21,5 @@
         'templates/assets.xml',
     ],
     'installable': True,
+    'pre_init_hook': 'pre_init_hook',
 }

--- a/account_financial_risk/hooks.py
+++ b/account_financial_risk/hooks.py
@@ -1,0 +1,13 @@
+# Copyright 2020 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+def pre_init_hook(cr):
+    cr.execute("""
+        ALTER TABLE account_invoice
+        ADD COLUMN company_currency_id integer""")
+    cr.execute("""
+        UPDATE account_invoice ai
+        SET company_currency_id = rc.currency_id
+        FROM res_company rc
+        WHERE ai.company_id = rc.id""")

--- a/account_financial_risk/migrations/11.0.3.0.0/pre-migration.py
+++ b/account_financial_risk/migrations/11.0.3.0.0/pre-migration.py
@@ -1,0 +1,7 @@
+# Copyright 2020 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo.addons.account_financial_risk.hooks import pre_init_hook
+
+
+def migrate(cr, version):
+    pre_init_hook(cr)

--- a/account_financial_risk/models/account_invoice.py
+++ b/account_financial_risk/models/account_invoice.py
@@ -1,11 +1,36 @@
 # Copyright 2016-2018 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 
 
 class AccountInvoice(models.Model):
     _inherit = 'account.invoice'
+
+    company_currency_id = fields.Many2one(store=True)
+    risk_currency_id = fields.Many2one(
+        related="partner_id.risk_currency_id")
+    risk_amount_total_currency = fields.Monetary(
+        string="Risk Amount Total",
+        currency_field="risk_currency_id",
+        compute="_compute_risk_amount_total_currency")
+
+    @api.multi
+    @api.depends('invoice_line_ids.price_subtotal', 'tax_line_ids.amount',
+                 'tax_line_ids.amount_rounding', 'currency_id', 'company_id',
+                 'date_invoice', 'type',
+                 'partner_id.credit_currency',
+                 'partner_id.manual_credit_currency_id',
+                 'partner_id.property_account_receivable_id.currency_id',
+                 'partner_id.country_id',
+                 'company_id.currency_id')
+    def _compute_risk_amount_total_currency(self):
+        for invoice in self:
+            invoice.risk_amount_total_currency = \
+                invoice.company_currency_id.with_context(
+                    date=invoice.date_invoice or fields.Date.context_today(
+                        self)).compute(invoice.amount_total_company_signed,
+                                       invoice.risk_currency_id, round=False)
 
     def risk_exception_msg(self):
         self.ensure_one()
@@ -14,14 +39,14 @@ class AccountInvoice(models.Model):
         if partner.risk_exception:
             exception_msg = _("Financial risk exceeded.\n")
         elif partner.risk_invoice_open_limit and (
-                (partner.risk_invoice_open + self.amount_total_company_signed)
+                (partner.risk_invoice_open + self.risk_amount_total_currency)
                 > partner.risk_invoice_open_limit):
             exception_msg = _(
                 "This invoice exceeds the open invoices risk.\n")
         # If risk_invoice_draft_include this invoice included in risk_total
         elif not partner.risk_invoice_draft_include and (
                 partner.risk_invoice_open_include and
-                (partner.risk_total + self.amount_total_company_signed) >
+                (partner.risk_total + self.risk_amount_total_currency) >
                 partner.credit_limit):
             exception_msg = _(
                 "This invoice exceeds the financial risk.\n")

--- a/account_financial_risk/models/res_partner.py
+++ b/account_financial_risk/models/res_partner.py
@@ -4,6 +4,7 @@
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
@@ -17,10 +18,13 @@ class ResPartner(models.Model):
     risk_invoice_draft_include = fields.Boolean(
         string='Include Draft Invoices', help='Full risk computation')
     risk_invoice_draft_limit = fields.Monetary(
-        string='Limit In Draft Invoices', help='Set 0 if it is not locked')
+        string='Limit In Draft Invoices',
+        currency_field="risk_currency_id",
+        help='Set 0 if it is not locked')
     risk_invoice_draft = fields.Monetary(
         compute='_compute_risk_invoice',
         string='Total Draft Invoices',
+        currency_field="risk_currency_id",
         help='Total amount of invoices in Draft or Pro-forma state')
     risk_invoice_open_include = fields.Boolean(
         string='Include Open Invoices/Principal Balance',
@@ -31,11 +35,13 @@ class ResPartner(models.Model):
     )
     risk_invoice_open_limit = fields.Monetary(
         string='Limit In Open Invoices/Principal Balance',
+        currency_field="risk_currency_id",
         help='Set 0 if it is not locked',
     )
     risk_invoice_open = fields.Monetary(
         compute='_compute_risk_account_amount',
         string='Total Open Invoices/Principal Balance',
+        currency_field="risk_currency_id",
         help='Residual amount of move lines not reconciled with the same '
              'account that is set as partner receivable and date maturity '
              'not exceeded, considering Due Margin set in account settings.',
@@ -49,11 +55,13 @@ class ResPartner(models.Model):
     )
     risk_invoice_unpaid_limit = fields.Monetary(
         string='Limit In Unpaid Invoices/Principal Balance',
+        currency_field="risk_currency_id",
         help='Set 0 if it is not locked',
     )
     risk_invoice_unpaid = fields.Monetary(
         compute='_compute_risk_account_amount',
         string='Total Unpaid Invoices/Principal Balance',
+        currency_field="risk_currency_id",
         help='Residual amount of move lines not reconciled with the same '
              'account that is set as partner receivable and date maturity '
              'exceeded, considering Due Margin set in account settings.',
@@ -67,11 +75,13 @@ class ResPartner(models.Model):
     )
     risk_account_amount_limit = fields.Monetary(
         string='Limit Other Account Open Amount',
+        currency_field="risk_currency_id",
         help='Set 0 if it is not locked',
     )
     risk_account_amount = fields.Monetary(
         compute='_compute_risk_account_amount',
         string='Total Other Account Open Amount',
+        currency_field="risk_currency_id",
         help='Residual amount of move lines not reconciled with distinct '
              'account that is set as partner receivable and date maturity '
              'not exceeded, considering Due Margin set in account settings.',
@@ -85,26 +95,82 @@ class ResPartner(models.Model):
     )
     risk_account_amount_unpaid_limit = fields.Monetary(
         string='Limit Other Account Unpaid Amount',
+        currency_field="risk_currency_id",
         help='Set 0 if it is not locked',
     )
     risk_account_amount_unpaid = fields.Monetary(
         compute='_compute_risk_account_amount',
         string='Total Other Account Unpaid Amount',
+        currency_field="risk_currency_id",
         help='Residual amount of move lines not reconciled with distinct '
              'account that is set as partner receivable and date maturity '
              'exceeded, considering Due Margin set in account settings.',
     )
     risk_total = fields.Monetary(
         compute='_compute_risk_exception',
-        string='Total Risk', help='Sum of total risk included')
+        string='Total Risk',
+        currency_field="risk_currency_id",
+        help='Sum of total risk included')
     risk_exception = fields.Boolean(
         compute='_compute_risk_exception',
         search='_search_risk_exception',
         string='Risk Exception',
-        help='It Indicate if partner risk exceeded')
+        help='It Indicate if partner risk exceeded',
+    )
     credit_policy = fields.Char()
     risk_allow_edit = fields.Boolean(compute='_compute_risk_allow_edit')
     credit_limit = fields.Float(track_visibility='onchange')
+    credit_currency = fields.Selection(
+        selection=[('company', 'Company Currency'),
+                   ('receivable', 'Receivable Currency'),
+                   ('pricelist', 'Pricelist Currency'),
+                   ('manual', 'Manual Credit Currency'),
+                   ], default='company', track_visibility='onchange',
+    )
+    manual_credit_currency_id = fields.Many2one(
+        comodel_name="res.currency", string="Manual Credit Currency",
+    )
+    risk_currency_id = fields.Many2one(
+        comodel_name="res.currency", compute='_compute_credit_currency')
+
+    @api.multi
+    @api.depends('credit_currency', 'manual_credit_currency_id',
+                 'property_account_receivable_id.currency_id',
+                 'country_id',
+                 'company_id.currency_id')
+    def _compute_credit_currency(self):
+        for partner in self:
+            if partner.credit_currency == 'manual':
+                partner.risk_currency_id = \
+                    partner.manual_credit_currency_id or partner.currency_id
+            elif partner.credit_currency == 'receivable':
+                partner.risk_currency_id = \
+                    partner.property_account_receivable_id.currency_id or \
+                    partner.currency_id
+            elif partner.credit_currency == 'pricelist':
+                partner.risk_currency_id = \
+                    partner.property_product_pricelist.currency_id or \
+                    partner.currency_id
+            else:
+                partner.risk_currency_id = partner.currency_id
+
+    @api.multi
+    @api.onchange('credit_currency')
+    def _onchange_credit_currency(self):
+        for partner in self:
+            if partner.credit_currency == 'manual':
+                partner.manual_credit_currency_id = partner.risk_currency_id
+            else:
+                partner.manual_credit_currency_id = False
+
+    @api.multi
+    @api.constrains('credit_currency', 'manual_credit_currency_id')
+    def _check_credit_currency(self):
+        for partner in self:
+            if partner.credit_currency == 'manual' \
+                    and not partner.manual_credit_currency_id:
+                raise ValidationError(
+                    _("Choose Manual Credit Currency."))
 
     def _compute_risk_allow_edit(self):
         self.update({'risk_allow_edit': self.env.user.has_group(
@@ -155,13 +221,20 @@ class ResPartner(models.Model):
             'risk_invoice_draft')
         total_group = self.env[model_name].sudo().read_group(
             domain=domain,
-            fields=['commercial_partner_id', 'amount_total_company_signed'],
-            groupby=['commercial_partner_id'],
+            fields=['commercial_partner_id', 'company_id',
+                    'amount_total_company_signed'],
+            groupby=['commercial_partner_id', 'company_id'],
             orderby='id',
+            lazy=False,
         )
         for group in total_group:
-            self.browse(group["commercial_partner_id"][0], self._prefetch) \
-                .risk_invoice_draft = group["amount_total_company_signed"]
+            partner = self.browse(
+                group["commercial_partner_id"][0], self._prefetch)
+            amount = group["amount_total_company_signed"]
+            company_currency = self.env['res.company'].browse(
+                group['company_id'][0]).currency_id
+            partner.risk_invoice_draft = company_currency.compute(
+                amount, partner.risk_currency_id, round=False)
 
     @api.model
     def _risk_account_groups(self):
@@ -226,39 +299,55 @@ class ResPartner(models.Model):
         # Partner receivable account determines if amount is in invoice field
         for reg in groups['open']['read_group']:
             if reg['partner_id'][0] != self.id:
-                continue
+                continue  # pragma: no cover
+            account = self.env['account.account'].browse(reg['account_id'][0])
             if self.property_account_receivable_id.id == reg['account_id'][0]:
-                vals['risk_invoice_open'] += reg['amount_residual']
+                vals['risk_invoice_open'] += \
+                    account.company_id.currency_id.compute(
+                        reg['amount_residual'], self.risk_currency_id,
+                        round=False)
             else:
-                vals['risk_account_amount'] += reg['amount_residual']
+                vals['risk_account_amount'] += \
+                    account.company_id.currency_id.compute(
+                        reg['amount_residual'], self.risk_currency_id,
+                        round=False)
         for reg in groups['unpaid']['read_group']:
+            account = self.env['account.account'].browse(reg['account_id'][0])
             if reg['partner_id'][0] != self.id:
                 continue  # pragma: no cover
             if self.property_account_receivable_id.id == reg['account_id'][0]:
-                vals['risk_invoice_unpaid'] += reg['amount_residual']
+                vals['risk_invoice_unpaid'] += \
+                    account.company_id.currency_id.compute(
+                        reg['amount_residual'], self.risk_currency_id,
+                        round=False)
             else:
-                vals['risk_account_amount_unpaid'] += reg['amount_residual']
+                vals['risk_account_amount_unpaid'] += \
+                    account.company_id.currency_id.compute(
+                        reg['amount_residual'], self.risk_currency_id,
+                        round=False)
         return vals
 
     @api.depends(lambda x: x._get_depends_compute_risk_exception())
     def _compute_risk_exception(self):
         risk_field_list = self._risk_field_list()
         for partner in self:
-            if not partner.customer:
-                partner.risk_exception = False
-                continue
             amount = 0.0
             risk_exception = False
+            if not partner.customer:
+                partner.risk_total = amount
+                partner.risk_exception = risk_exception
+                continue
             for risk_field in risk_field_list:
                 field_value = getattr(partner, risk_field[0], 0.0)
                 max_value = getattr(partner, risk_field[1], 0.0)
+                include = getattr(partner, risk_field[2], False)
                 if max_value and field_value > max_value:
                     risk_exception = True
-                if getattr(partner, risk_field[2], False):
+                if include:
                     amount += field_value
-            partner.risk_total = amount
             if partner.credit_limit and amount > partner.credit_limit:
                 risk_exception = True
+            partner.risk_total = amount
             partner.risk_exception = risk_exception
 
     @api.model

--- a/account_financial_risk/views/account_financial_risk_view.xml
+++ b/account_financial_risk/views/account_financial_risk_view.xml
@@ -8,7 +8,7 @@
             <pivot string="Invoices" disable_linking="True">
                 <field name="partner_id" type="row"/>
                 <field name="date_due" interval="month" type="col"/>
-                <field name="amount_total" type="measure"/>
+                <field name="amount_total_company_signed" type="measure"/>
             </pivot>
         </field>
     </record>

--- a/account_financial_risk/views/res_partner_view.xml
+++ b/account_financial_risk/views/res_partner_view.xml
@@ -20,54 +20,68 @@
                                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                                 <button name="open_risk_pivot_info" type="object" class="oe_link"
                                         context="{'open_risk_field': 'risk_invoice_draft'}">
-                                    <field name="risk_invoice_draft" nolabel="1"/>
+                                    <field name="risk_invoice_draft" nolabel="1" widget='monetary' options="{'currency_field': 'risk_currency_id'}"/>
                                 </button>
                                 <field name="risk_invoice_open_include"
                                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                                 <button name="open_risk_pivot_info" type="object" class="oe_link"
                                         context="{'open_risk_field': 'risk_invoice_open'}">
-                                    <field name="risk_invoice_open" nolabel="1"/>
+                                    <field name="risk_invoice_open" nolabel="1" widget='monetary' options="{'currency_field': 'risk_currency_id'}"/>
                                 </button>
                                 <field name="risk_invoice_unpaid_include"
                                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                                 <button name="open_risk_pivot_info" type="object" class="oe_link"
                                         context="{'open_risk_field': 'risk_invoice_unpaid'}">
-                                    <field name="risk_invoice_unpaid" nolabel="1"/>
+                                    <field name="risk_invoice_unpaid" nolabel="1" widget='monetary' options="{'currency_field': 'risk_currency_id'}"/>
                                 </button>
                                 <field name="risk_account_amount_include"
                                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                                 <button name="open_risk_pivot_info" type="object" class="oe_link"
                                         context="{'open_risk_field': 'risk_account_amount'}">
-                                    <field name="risk_account_amount" nolabel="1"/>
+                                    <field name="risk_account_amount" nolabel="1" widget='monetary' options="{'currency_field': 'risk_currency_id'}"/>
                                 </button>
                                 <field name="risk_account_amount_unpaid_include"
                                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                                 <button name="open_risk_pivot_info" type="object" class="oe_link"
                                         context="{'open_risk_field': 'risk_account_amount_unpaid'}">
-                                    <field name="risk_account_amount_unpaid" nolabel="1"/>
+                                    <field name="risk_account_amount_unpaid" nolabel="1" widget='monetary' options="{'currency_field': 'risk_currency_id'}"/>
                                 </button>
-                                <field name="risk_total" colspan="3" class="oe_subtotal_footer_separator"/>
+                                <field name="risk_total" colspan="3" class="oe_subtotal_footer_separator" widget='monetary' options="{'currency_field': 'risk_currency_id'}"/>
                             </group>
                         </group>
                         <group string="Specific Limits" name="risk_limits" class="o_group_col_6">
                             <group class="oe_subtotal_footer" style="float: left !important;">
                                 <field name="risk_invoice_draft_limit"
+                                       widget='monetary' options="{'currency_field': 'risk_currency_id'}"
                                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                                 <field name="risk_invoice_open_limit"
+                                       widget='monetary' options="{'currency_field': 'risk_currency_id'}"
                                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                                 <field name="risk_invoice_unpaid_limit"
+                                       widget='monetary' options="{'currency_field': 'risk_currency_id'}"
                                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                                 <field name="risk_account_amount_limit"
+                                       widget='monetary' options="{'currency_field': 'risk_currency_id'}"
                                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                                 <field name="risk_account_amount_unpaid_limit"
+                                       widget='monetary' options="{'currency_field': 'risk_currency_id'}"
                                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                                 <field name="risk_allow_edit" invisible="1"/>
                             </group>
                         </group>
                     </group>
                     <group string="Info" col="4">
+                        <label for="credit_currency"/>
+                        <div class="o_row">
+                            <field name="credit_currency"
+                                   attrs="{'readonly': [('risk_allow_edit', '=', False)]}" nolabel="1"/>
+                            <span>(<field name="risk_currency_id" readonly="1" nolabel="1"/>)</span>
+                        </div>
+                        <field name="manual_credit_currency_id"
+                               options="{'no_create': True}"
+                               attrs="{'readonly': [('risk_allow_edit', '=', False)], 'invisible': [('credit_currency', '!=', 'manual')]}"/>
                         <field name="credit_limit"
-                               widget="monetary"
+                               widget="monetary" options="{'currency_field': 'risk_currency_id'}"
                                attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                         <field name="credit_policy"
                                attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>

--- a/account_payment_return_financial_risk/models/res_partner.py
+++ b/account_payment_return_financial_risk/models/res_partner.py
@@ -13,10 +13,13 @@ class ResPartner(models.Model):
              'Residual amount of move lines not reconciled with returned '
              'lines related.')
     risk_payment_return_limit = fields.Monetary(
-        string='Limit Payments Returns', help='Set 0 if it is not locked')
+        string='Limit Payments Returns',
+        currency_field="risk_currency_id",
+        help='Set 0 if it is not locked')
     risk_payment_return = fields.Monetary(
         compute='_compute_risk_account_amount',
         string='Total Payments Returns',
+        currency_field="risk_currency_id",
         help='Residual amount of move lines not reconciled with returned '
              'lines related.')
 
@@ -43,9 +46,14 @@ class ResPartner(models.Model):
     @api.multi
     def _prepare_risk_account_vals(self, groups):
         vals = super(ResPartner, self)._prepare_risk_account_vals(groups)
-        vals['risk_payment_return'] = sum(
-            reg['amount_residual'] for reg in groups['returned']['read_group']
-            if reg['partner_id'][0] == self.id)
+        vals.update({'risk_payment_return': 0.0})
+        for reg in groups['returned']['read_group']:
+            if reg['partner_id'][0] != self.id:
+                continue  # pragma: no cover
+            account = self.env['account.account'].browse(reg['account_id'][0])
+            vals['risk_payment_return'] += \
+                account.company_id.currency_id.compute(
+                    reg['amount_residual'], self.risk_currency_id, round=False)
         return vals
 
     @api.model

--- a/account_payment_return_financial_risk/views/res_partner_view.xml
+++ b/account_payment_return_financial_risk/views/res_partner_view.xml
@@ -11,11 +11,12 @@
                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                 <button name="open_risk_pivot_info" type="object" class="oe_link"
                         context="{'open_risk_field': 'risk_payment_return'}">
-                    <field name="risk_payment_return" nolabel="1"/>
+                    <field name="risk_payment_return" nolabel="1" widget='monetary' options="{'currency_field': 'risk_currency_id'}"/>
                 </button>
             </field>
             <field name="risk_account_amount_limit" position="before">
                 <field name="risk_payment_return_limit"
+                       widget='monetary' options="{'currency_field': 'risk_currency_id'}"
                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
             </field>
         </field>

--- a/sale_financial_risk/views/res_partner_view.xml
+++ b/sale_financial_risk/views/res_partner_view.xml
@@ -14,11 +14,12 @@
                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
                 <button name="open_risk_pivot_info" type="object" class="oe_link"
                         context="{'open_risk_field': 'risk_sale_order'}">
-                    <field name="risk_sale_order" nolabel="1"/>
+                    <field name="risk_sale_order" nolabel="1" widget='monetary' options="{'currency_field': 'risk_currency_id'}"/>
                 </button>
             </field>
             <field name="risk_invoice_draft_limit" position="before">
                 <field name="risk_sale_order_limit"
+                       widget='monetary' options="{'currency_field': 'risk_currency_id'}"
                        attrs="{'readonly': [('risk_allow_edit', '=', False)]}"/>
             </field>
 


### PR DESCRIPTION
Well, in https://github.com/OCA/credit-control/pull/63#issuecomment-642872888, @carlosdauden said that if we add a configuration parameter, then everybody can be happy in the way to show the currencies. Thus I added a `selection`, which let's choose between Company Currency, Receivable Currency, Pricelist Currency, and Manual Credit Currency. Note: Company Currency is the default. All risk values are in the risk currency, the one chosen.

Please, show your opinion.