### PR TITLE
[12.0][FIX] account_credit_control: update website to current git repository

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -17,7 +17,7 @@
      'account',
      'mail',
  ],
- 'website': 'https://github.com/OCA/account-financial-tools',
+ 'website': 'https://github.com/OCA/credit-control',
  'data': [
      # Security
      "security/res_groups.xml",


### PR DESCRIPTION
Change website link in `__manifest__.py` from `account-financial-tools` to `credit-control` repository