### PR TITLE
[12.0][IMP]sale_financial_risk: Add sale orders in done state to risk calculation if sale auto done is enabled.

### DIFF
--- a/sale_financial_risk/__manifest__.py
+++ b/sale_financial_risk/__manifest__.py
@@ -13,6 +13,7 @@
     'data': [
         'views/res_partner_view.xml',
         'views/sale_financial_risk_view.xml',
+        'views/res_config_settings.xml'
     ],
     'installable': True,
     'pre_init_hook': 'pre_init_hook',

--- a/sale_financial_risk/models/__init__.py
+++ b/sale_financial_risk/models/__init__.py
@@ -1,3 +1,4 @@
 from . import payment
 from . import res_partner
 from . import sale
+from . import res_config_settings

--- a/sale_financial_risk/models/res_config_settings.py
+++ b/sale_financial_risk/models/res_config_settings.py
@@ -1,0 +1,10 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    include_risk_sale_order_done = fields.Boolean(
+        "Include locked sale orders into risk calculation",
+        config_parameter='sale_financial_risk.include_risk_sale_order_done')

--- a/sale_financial_risk/models/res_partner.py
+++ b/sale_financial_risk/models/res_partner.py
@@ -21,8 +21,9 @@ class ResPartner(models.Model):
         commercial_partners = self.filtered(lambda p: (
             p.customer and p.id and p == p.commercial_partner_id
         ))
+        risk_states = self.env['sale.order']._get_risk_states()
         return self._get_risk_company_domain() + [
-            ('state', '=', 'sale'),
+            ('state', 'in', risk_states),
             ('commercial_partner_id', 'in', commercial_partners.ids),
         ]
 

--- a/sale_financial_risk/models/sale.py
+++ b/sale_financial_risk/models/sale.py
@@ -37,6 +37,14 @@ class SaleOrder(models.Model):
                 }).action_show()
         return super(SaleOrder, self).action_confirm()
 
+    @api.model
+    def _get_risk_states(self):
+        risk_states = ['sale']
+        if self.env['ir.config_parameter'].sudo().get_param(
+                'sale_financial_risk.include_risk_sale_order_done'):
+            risk_states.append('done')
+        return risk_states
+
 
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
@@ -69,8 +77,9 @@ class SaleOrderLine(models.Model):
                  'product_uom_qty',
                  'qty_invoiced')
     def _compute_risk_amount(self):
+        risk_states = self.env['sale.order']._get_risk_states()
         for line in self:
-            if line.state != 'sale':
+            if line.state not in risk_states:
                 line.risk_amount = 0.0
                 continue
             qty = line.product_uom_qty

--- a/sale_financial_risk/views/res_config_settings.xml
+++ b/sale_financial_risk/views/res_config_settings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.credit.control</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account_financial_risk.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='allow_overrisk_invoice_validation']/../.." position="inside">
+                <div class="row col-xs-12 o_setting_box">
+                    <div class="o_setting_left_pane">
+
+                        <field name="include_risk_sale_order_done"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label string="Include orders in done state" for="include_risk_sale_order_done"/>
+                        <div class="text-muted">
+                            Include locked sale orders into risk calculation
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
https://github.com/OCA/credit-control/issues/74

cc: @rafamarpe @carlosdauden 