### PR TITLE
[12.0][IMP] account_credit_control: preventive policy.

### DIFF
--- a/account_credit_control/README.rst
+++ b/account_credit_control/README.rst
@@ -39,8 +39,10 @@ Configuration
 
 Configure the policies and policy levels in ``Invoicing  > Configuration >
 Credit Control > Credit Control Policies``.
-You can define as many policy levels as you need. You must set on which
-accounts are applied every Credit Control Policy under Accounts tab.
+You can define as many policy levels as you need and you can even define
+levels with a negative number of days to run notifications days in advance.
+You must set on which accounts are applied every Credit Control Policy
+under Accounts tab.
 
 Configure a tolerance for the Credit control and a default policy
 applied on all partners in each company, under the Accounting tab in your
@@ -95,10 +97,14 @@ Contributors
 * Guewen Baconnier (Camptocamp)
 * Sylvain Van Hoof (Okia SPRL) <sylvain@okia.be>
 * Akim Juillerat (Camptocamp) <akim.juillerat@camptocamp.com>
-* Vicent Cubells (Tecnativa) <vicent.cubells@tecnativa.com>
 * Kinner Vachhani (Access Bookings Ltd) <kin.vachhani@gmail.com>
 * Raf Ven <raf.ven@dynapps.be>
 * Quentin Groulard (ACSONE) <quentin.groulard@acsone.eu>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Vicent Cubells
+  * Ernesto Tejeda
+  * Pedro M. Baeza
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_credit_control/readme/CONFIGURE.rst
+++ b/account_credit_control/readme/CONFIGURE.rst
@@ -1,7 +1,9 @@
 Configure the policies and policy levels in ``Invoicing  > Configuration >
 Credit Control > Credit Control Policies``.
-You can define as many policy levels as you need. You must set on which
-accounts are applied every Credit Control Policy under Accounts tab.
+You can define as many policy levels as you need and you can even define
+levels with a negative number of days to run notifications days in advance.
+You must set on which accounts are applied every Credit Control Policy
+under Accounts tab.
 
 Configure a tolerance for the Credit control and a default policy
 applied on all partners in each company, under the Accounting tab in your

--- a/account_credit_control/readme/CONTRIBUTORS.rst
+++ b/account_credit_control/readme/CONTRIBUTORS.rst
@@ -2,7 +2,11 @@
 * Guewen Baconnier (Camptocamp)
 * Sylvain Van Hoof (Okia SPRL) <sylvain@okia.be>
 * Akim Juillerat (Camptocamp) <akim.juillerat@camptocamp.com>
-* Vicent Cubells (Tecnativa) <vicent.cubells@tecnativa.com>
 * Kinner Vachhani (Access Bookings Ltd) <kin.vachhani@gmail.com>
 * Raf Ven <raf.ven@dynapps.be>
 * Quentin Groulard (ACSONE) <quentin.groulard@acsone.eu>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Vicent Cubells
+  * Ernesto Tejeda
+  * Pedro M. Baeza

--- a/account_credit_control/static/description/index.html
+++ b/account_credit_control/static/description/index.html
@@ -389,8 +389,10 @@ identify outstanding debt beyond tolerance level and setup followup method.</p>
 <h1><a class="toc-backref" href="#id1">Configuration</a></h1>
 <p>Configure the policies and policy levels in <tt class="docutils literal">Invoicing&nbsp; &gt; Configuration &gt;
 Credit Control &gt; Credit Control Policies</tt>.
-You can define as many policy levels as you need. You must set on which
-accounts are applied every Credit Control Policy under Accounts tab.</p>
+You can define as many policy levels as you need and you can even define
+levels with a negative number of days to run notifications days in advance.
+You must set on which accounts are applied every Credit Control Policy
+under Accounts tab.</p>
 <p>Configure a tolerance for the Credit control and a default policy
 applied on all partners in each company, under the Accounting tab in your
 company form.</p>
@@ -443,10 +445,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Guewen Baconnier (Camptocamp)</li>
 <li>Sylvain Van Hoof (Okia SPRL) &lt;<a class="reference external" href="mailto:sylvain&#64;okia.be">sylvain&#64;okia.be</a>&gt;</li>
 <li>Akim Juillerat (Camptocamp) &lt;<a class="reference external" href="mailto:akim.juillerat&#64;camptocamp.com">akim.juillerat&#64;camptocamp.com</a>&gt;</li>
-<li>Vicent Cubells (Tecnativa) &lt;<a class="reference external" href="mailto:vicent.cubells&#64;tecnativa.com">vicent.cubells&#64;tecnativa.com</a>&gt;</li>
 <li>Kinner Vachhani (Access Bookings Ltd) &lt;<a class="reference external" href="mailto:kin.vachhani&#64;gmail.com">kin.vachhani&#64;gmail.com</a>&gt;</li>
 <li>Raf Ven &lt;<a class="reference external" href="mailto:raf.ven&#64;dynapps.be">raf.ven&#64;dynapps.be</a>&gt;</li>
 <li>Quentin Groulard (ACSONE) &lt;<a class="reference external" href="mailto:quentin.groulard&#64;acsone.eu">quentin.groulard&#64;acsone.eu</a>&gt;</li>
+<li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
+<li>Vicent Cubells</li>
+<li>Ernesto Tejeda</li>
+<li>Pedro M. Baeza</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Negative numbers can now be specified in policy levels.

![2020-08-21_11-35](https://user-images.githubusercontent.com/38267832/90908496-77a91c00-e3a2-11ea-8d33-87cad4de8ea9.png)


cc @Tecnativa TT24674