### PR TITLE
[FIX][13.0] sale_financial_risk: skip section/notes to prevent errors during compute

### DIFF
--- a/sale_financial_risk/models/sale.py
+++ b/sale_financial_risk/models/sale.py
@@ -77,7 +77,11 @@ class SaleOrderLine(models.Model):
     )
     def _compute_risk_amount(self):
         for line in self:
-            if line.state != "sale":
+            skip = (
+                line.state != "sale"
+                or bool(line.display_type)
+            )
+            if skip:
                 line.risk_amount = 0.0
                 continue
             qty = line.product_uom_qty


### PR DESCRIPTION
Before this PR, the compute method could crash during the initialization on non normal SO lines. (```line.product_uom``` equals to False and leads the float_round method to raise an error).