### PR TITLE
[IMP] account_credit_control: Set multicompany usage. Remove warnings

### DIFF
--- a/account_credit_control/models/credit_control_line.py
+++ b/account_credit_control/models/credit_control_line.py
@@ -208,6 +208,7 @@ class CreditControlLine(models.Model):
         lines,
         level,
         controlling_date,
+        company,
         check_tolerance=True,
         default_lines_vals=None,
     ):
@@ -223,6 +224,7 @@ class CreditControlLine(models.Model):
         :param controlling_date: date string of the credit controlling date.
                                  Generally it should be the same
                                  as create date
+        :param company: res.company
         :param default_lines_vals: default values to create new credit control
                                    lines with
         :param check_tolerance: boolean if True credit line
@@ -233,15 +235,18 @@ class CreditControlLine(models.Model):
         :returns: recordset of created credit lines
         """
         currency_obj = self.env['res.currency']
-        user = self.env.user
         currencies = currency_obj.search([])
 
         tolerance = {}
-        tolerance_base = user.company_id.credit_control_tolerance
-        user_currency = user.company_id.currency_id
+        tolerance_base = company.credit_control_tolerance
+        user_currency = company.currency_id
         for currency in currencies:
-            tolerance[currency.id] = currency.compute(
-                tolerance_base, user_currency)
+            tolerance[currency.id] = currency._convert(
+                tolerance_base,
+                user_currency,
+                company,
+                controlling_date or fields.Date.today()
+            )
 
         lines_to_create = []
         lines_to_write = self.browse()

--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -67,23 +67,27 @@ class CreditControlPolicy(models.Model):
             record.policy_sign = mapping[policy_sign]
 
     @api.multi
-    def _move_lines_domain(self, controlling_date):
+    def _move_lines_domain(self, credit_control_run):
         """ Build the default domain for searching move lines """
         self.ensure_one()
         domain = [
             ('account_id', 'in', self.account_ids.ids),
             ('reconciled', '=', False),
             ('partner_id', '!=', False),
+            ('company_id', '=', credit_control_run.company_id.id),
         ]
+        # We need to set the company in order to work properly with multi-companies.
+        # If we have Company A and Company B (child of A), we might be able to run this
+        # for company B from Company A view.
         if self.policy_sign == "negative":
-            domain.append(('date_maturity', '>=', controlling_date))
+            domain.append(('date_maturity', '>=', credit_control_run.date))
         elif self.policy_sign == "positive":
-            domain.append(('date_maturity', '<=', controlling_date))
+            domain.append(('date_maturity', '<=', credit_control_run.date))
         return domain
 
     @api.multi
     @api.returns('account.move.line')
-    def _due_move_lines(self, controlling_date):
+    def _due_move_lines(self, credit_control_run):
         """ Get the due move lines for the policy of the company.
 
         The set of ids will be reduced and extended according
@@ -96,15 +100,14 @@ class CreditControlPolicy(models.Model):
         """
         self.ensure_one()
         move_l_obj = self.env['account.move.line']
-        user = self.env.user
-        if user.company_id.credit_policy_id.id != self.id:
+        if credit_control_run.company_id.credit_policy_id.id != self.id:
             return move_l_obj
-        domain_line = self._move_lines_domain(controlling_date)
+        domain_line = self._move_lines_domain(credit_control_run)
         return move_l_obj.search(domain_line)
 
     @api.multi
     @api.returns('account.move.line')
-    def _move_lines_subset(self, controlling_date, model, move_relation_field):
+    def _move_lines_subset(self, credit_control_run, model, move_relation_field):
         """ Get the move lines related to one model for a policy.
 
         Do not use direct SQL in order to respect security rules.
@@ -124,7 +127,7 @@ class CreditControlPolicy(models.Model):
         self.ensure_one()
         # MARK possible place for a good optimisation
         my_obj = self.env[model].with_context(active_test=False)
-        default_domain = self._move_lines_domain(controlling_date)
+        default_domain = self._move_lines_domain(credit_control_run)
 
         to_add = self.env['account.move.line']
         to_remove = self.env['account.move.line']
@@ -150,7 +153,7 @@ class CreditControlPolicy(models.Model):
 
     @api.multi
     @api.returns('account.move.line')
-    def _get_partner_related_lines(self, controlling_date):
+    def _get_partner_related_lines(self, credit_control_run):
         """ Get the move lines for a policy related to a partner.
 
         :param str controlling_date: date of credit control
@@ -158,12 +161,12 @@ class CreditControlPolicy(models.Model):
             the process
         """
         return self._move_lines_subset(
-            controlling_date, 'res.partner', 'partner_id',
+            credit_control_run, 'res.partner', 'partner_id',
         )
 
     @api.multi
     @api.returns('account.move.line')
-    def _get_invoice_related_lines(self, controlling_date):
+    def _get_invoice_related_lines(self, credit_control_run):
         """ Get the move lines for a policy related to an invoice.
 
         :param str controlling_date: date of credit control
@@ -171,12 +174,12 @@ class CreditControlPolicy(models.Model):
             the process
         """
         return self._move_lines_subset(
-            controlling_date, 'account.invoice', 'invoice_id',
+            credit_control_run, 'account.invoice', 'invoice_id',
         )
 
     @api.multi
     @api.returns('account.move.line')
-    def _get_move_lines_to_process(self, controlling_date):
+    def _get_move_lines_to_process(self, credit_control_run):
         """ Build a list of move lines ids to include in a run
         for a policy at a given date.
 
@@ -185,10 +188,10 @@ class CreditControlPolicy(models.Model):
         """
         self.ensure_one()
         # there is a priority between the lines, depicted by the calls below
-        lines = self._due_move_lines(controlling_date)
-        to_add, to_remove = self._get_partner_related_lines(controlling_date)
+        lines = self._due_move_lines(credit_control_run)
+        to_add, to_remove = self._get_partner_related_lines(credit_control_run)
         lines = (lines | to_add) - to_remove
-        to_add, to_remove = self._get_invoice_related_lines(controlling_date)
+        to_add, to_remove = self._get_invoice_related_lines(credit_control_run)
         lines = (lines | to_add) - to_remove
         return lines
 
@@ -229,11 +232,12 @@ class CreditControlPolicy(models.Model):
 
     @api.multi
     def _generate_credit_lines(
-        self, controlling_date, default_lines_vals=None
+        self, credit_control_run, default_lines_vals=None
     ):
         self.ensure_one()
+        controlling_date = credit_control_run.date
         credit_line_model = self.env['credit.control.line']
-        lines = self._get_move_lines_to_process(controlling_date)
+        lines = self._get_move_lines_to_process(credit_control_run)
         manual_lines = self._lines_different_policy(lines)
         lines -= manual_lines
         policy_lines_generated = credit_line_model
@@ -247,6 +251,7 @@ class CreditControlPolicy(models.Model):
                     level_lines,
                     level,
                     controlling_date,
+                    credit_control_run.company_id,
                     default_lines_vals=default_lines_vals,
                 )
         if policy_lines_generated:

--- a/account_credit_control/models/credit_control_run.py
+++ b/account_credit_control/models/credit_control_run.py
@@ -144,7 +144,7 @@ class CreditControlRun(models.Model):
                 policy_manual_lines,
                 policy_lines_generated,
                 policy_report,
-            ) = policy._generate_credit_lines(self.date, {'run_id': self.id})
+            ) = policy._generate_credit_lines(self, {'run_id': self.id})
             manually_managed_lines |= policy_manual_lines
             generated |= policy_lines_generated
             report += policy_report

--- a/account_credit_control/views/credit_control_run.xml
+++ b/account_credit_control/views/credit_control_run.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <tree string="Credit control run">
                 <field name="date"/>
+                <field name="company_id" groups="base.group_multi_company"/>
                 <field name="state"/>
             </tree>
         </field>

--- a/account_credit_control/wizard/credit_control_policy_changer.py
+++ b/account_credit_control/wizard/credit_control_policy_changer.py
@@ -119,12 +119,15 @@ class CreditControlPolicyChanger(models.TransientModel):
         # As it is a manual action
         # We also ignore rounding tolerance
         create = credit_line_obj.create_or_update_from_mv_lines
-        generated_lines = create(
-            self.move_line_ids,
-            self.new_policy_level_id,
-            controlling_date,
-            check_tolerance=False,
-        )
+        generated_lines = credit_line_obj
+        for line in self.move_line_ids:
+            generated_lines |= create(
+                line,
+                self.new_policy_level_id,
+                controlling_date,
+                line.company_id,
+                check_tolerance=False,
+            )
         self._set_invoice_policy(self.move_line_ids, self.new_policy_id)
 
         if not generated_lines:


### PR DESCRIPTION
I have detected that the generation was not working properly on multicompany environments, this PR tries to solve the issue