### PR TITLE
[13.0][FIX] account_credit_control avoid cancelled moves

### DIFF
--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -41,6 +41,7 @@ class CreditControlPolicy(models.Model):
             ("date_maturity", "<=", controlling_date),
             ("reconciled", "=", False),
             ("partner_id", "!=", False),
+            ("parent_state", "=", "posted"),
         ]
 
     @api.returns("account.move.line")


### PR DESCRIPTION
A credit control run can currently contain != posted moves (i.e. cancelled moves). This fix proposes adding a domain to fix this.

@pedrobaeza 