### PR TITLE
[FIX] sale_financial_risk: fixed bug when the line of sale order is a…

### DIFF
--- a/sale_financial_risk/models/sale.py
+++ b/sale_financial_risk/models/sale.py
@@ -84,7 +84,7 @@ class SaleOrderLine(models.Model):
     )
     def _compute_risk_amount(self):
         for line in self:
-            if line.state != "sale":
+            if line.state != "sale" or line.display_type:
                 line.risk_amount = 0.0
                 continue
             qty = line.product_uom_qty


### PR DESCRIPTION
Step to reproduce

add lines to a sale order than be a note or a section. 

current behavior

When try to confirm the sale order get this error : 
"AssertionError: precision_rounding must be positive, got 0.0"

expected behavior

Can confirm the sale order without problems. 