### PR TITLE
[FIX] account_credit_control: Load data correctly

### DIFF
--- a/account_credit_control/README.rst
+++ b/account_credit_control/README.rst
@@ -103,7 +103,6 @@ Contributors
 * Guewen Baconnier (Camptocamp)
 * Sylvain Van Hoof (Okia SPRL) <sylvain@okia.be>
 * Akim Juillerat (Camptocamp) <akim.juillerat@camptocamp.com>
-* Vicent Cubells (Tecnativa) <vicent.cubells@tecnativa.com>
 * Kinner Vachhani (Access Bookings Ltd) <kin.vachhani@gmail.com>
 * Raf Ven <raf.ven@dynapps.be>
 * Quentin Groulard (ACSONE) <quentin.groulard@acsone.eu>
@@ -114,6 +113,7 @@ Contributors
   * Ernesto Tejeda
   * Pedro M. Baeza
   * Jairo Llopis
+  * João Marques
 
 * Enric Tobella <etobella@creublanca.es>
 

--- a/account_credit_control/data/data.xml
+++ b/account_credit_control/data/data.xml
@@ -21,21 +21,6 @@
   ${object.policy_level_id.custom_mail_text | safe}
   ]]></field>
     </record>
-    <record id="a_sale" model="account.account">
-        <field name="code">X2020</field>
-        <field name="name">Product Sales - (test)</field>
-        <field name="user_type_id" ref="account.data_account_type_revenue" />
-        <field name="tag_ids" eval="[(6,0,[ref('account.account_tag_operating')])]" />
-    </record>
-    <!-- sales journal -->
-    <record id="sales_journal" model="account.journal">
-        <field name="name">Customer Invoices - Test</field>
-        <field name="code">TINV</field>
-        <field name="type">sale</field>
-        <field name="default_credit_account_id" ref="a_sale" />
-        <field name="default_debit_account_id" ref="a_sale" />
-        <field name="refund_sequence" eval="True" />
-    </record>
     <!-- policy no follow -->
     <record model="credit.control.policy" id="credit_control_no_follow">
         <field name="name">No follow</field>

--- a/account_credit_control/readme/CONTRIBUTORS.rst
+++ b/account_credit_control/readme/CONTRIBUTORS.rst
@@ -2,7 +2,6 @@
 * Guewen Baconnier (Camptocamp)
 * Sylvain Van Hoof (Okia SPRL) <sylvain@okia.be>
 * Akim Juillerat (Camptocamp) <akim.juillerat@camptocamp.com>
-* Vicent Cubells (Tecnativa) <vicent.cubells@tecnativa.com>
 * Kinner Vachhani (Access Bookings Ltd) <kin.vachhani@gmail.com>
 * Raf Ven <raf.ven@dynapps.be>
 * Quentin Groulard (ACSONE) <quentin.groulard@acsone.eu>
@@ -13,5 +12,6 @@
   * Ernesto Tejeda
   * Pedro M. Baeza
   * Jairo Llopis
+  * João Marques
 
 * Enric Tobella <etobella@creublanca.es>

--- a/account_credit_control/static/description/index.html
+++ b/account_credit_control/static/description/index.html
@@ -447,7 +447,6 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Guewen Baconnier (Camptocamp)</li>
 <li>Sylvain Van Hoof (Okia SPRL) &lt;<a class="reference external" href="mailto:sylvain&#64;okia.be">sylvain&#64;okia.be</a>&gt;</li>
 <li>Akim Juillerat (Camptocamp) &lt;<a class="reference external" href="mailto:akim.juillerat&#64;camptocamp.com">akim.juillerat&#64;camptocamp.com</a>&gt;</li>
-<li>Vicent Cubells (Tecnativa) &lt;<a class="reference external" href="mailto:vicent.cubells&#64;tecnativa.com">vicent.cubells&#64;tecnativa.com</a>&gt;</li>
 <li>Kinner Vachhani (Access Bookings Ltd) &lt;<a class="reference external" href="mailto:kin.vachhani&#64;gmail.com">kin.vachhani&#64;gmail.com</a>&gt;</li>
 <li>Raf Ven &lt;<a class="reference external" href="mailto:raf.ven&#64;dynapps.be">raf.ven&#64;dynapps.be</a>&gt;</li>
 <li>Quentin Groulard (ACSONE) &lt;<a class="reference external" href="mailto:quentin.groulard&#64;acsone.eu">quentin.groulard&#64;acsone.eu</a>&gt;</li>
@@ -457,6 +456,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Ernesto Tejeda</li>
 <li>Pedro M. Baeza</li>
 <li>Jairo Llopis</li>
+<li>João Marques</li>
 </ul>
 </li>
 <li>Enric Tobella &lt;<a class="reference external" href="mailto:etobella&#64;creublanca.es">etobella&#64;creublanca.es</a>&gt;</li>

--- a/account_credit_control/tests/test_account_move.py
+++ b/account_credit_control/tests/test_account_move.py
@@ -1,24 +1,42 @@
 # Copyright 2017 Okia SPRL (https://okia.be)
+# Copyright 2020 Tecnativa - João Marques
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from datetime import datetime
 
 from dateutil import relativedelta
 
-from odoo import fields
+from odoo import fields, tools
 from odoo.exceptions import UserError
+from odoo.modules.module import get_resource_path
 from odoo.tests import tagged
 from odoo.tests.common import Form, TransactionCase
 
 
 @tagged("post_install", "-at_install")
 class TestAccountInvoice(TransactionCase):
+    def _load(self, module, *args):
+        tools.convert_file(
+            self.cr,
+            module,
+            get_resource_path(module, *args),
+            {},
+            "init",
+            False,
+            "test",
+            self.registry._assertion_report,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self._load("account", "test", "account_minimal_test.xml")
+
     def test_action_cancel(self):
         """
         Test the method action_cancel on invoice
         We will create an old invoice, generate a control run
         and check if I can unlink this invoice
         """
-        journal = self.env.ref("account_credit_control.sales_journal")
+        journal = self.env.ref("account.sales_journal")
 
         account_type_rec = self.env.ref("account.data_account_type_receivable")
         account = self.env["account.account"].create(
@@ -112,7 +130,7 @@ class TestAccountInvoice(TransactionCase):
         We will create an old invoice, generate a control run
         and check if I can unlink this invoice
         """
-        journal = self.env.ref("account_credit_control.sales_journal")
+        journal = self.env.ref("account.sales_journal")
 
         account_type_rec = self.env.ref("account.data_account_type_receivable")
         account = self.env["account.account"].create(
@@ -193,7 +211,7 @@ class TestAccountInvoice(TransactionCase):
         We will create an invoice, change credit policy and check
         if it has change the policy on invoice
         """
-        journal = self.env.ref("account_credit_control.sales_journal")
+        journal = self.env.ref("account.sales_journal")
 
         account_type_rec = self.env.ref("account.data_account_type_receivable")
         account = self.env["account.account"].create(

--- a/account_credit_control/tests/test_credit_control_run.py
+++ b/account_credit_control/tests/test_credit_control_run.py
@@ -1,23 +1,39 @@
 # Copyright 2017 Okia SPRL (https://okia.be)
-# Copyright 2020 Manuel Calero - Tecnativa
+# Copyright 2020 Tecnativa - Manuel Calero
+# Copyright 2020 Tecnativa - João Marques
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import re
 from datetime import datetime
 
 from dateutil import relativedelta
 
-from odoo import fields
+from odoo import fields, tools
 from odoo.exceptions import UserError
+from odoo.modules.module import get_resource_path
 from odoo.tests import tagged
 from odoo.tests.common import Form, TransactionCase
 
 
 @tagged("post_install", "-at_install")
 class TestCreditControlRun(TransactionCase):
+    def _load(self, module, *args):
+        tools.convert_file(
+            self.cr,
+            module,
+            get_resource_path(module, *args),
+            {},
+            "init",
+            False,
+            "test",
+            self.registry._assertion_report,
+        )
+
     def setUp(self):
         super(TestCreditControlRun, self).setUp()
 
-        journal = self.env.ref("account_credit_control.sales_journal")
+        self._load("account", "test", "account_minimal_test.xml")
+
+        journal = self.env.ref("account.sales_journal")
 
         account_type_rec = self.env.ref("account.data_account_type_receivable")
         account = self.env["account.account"].create(


### PR DESCRIPTION
Some data was being declared repeating demo data from Odoo `account`
addon.
See
https://github.com/odoo/odoo/blob/13.0/addons/account/test/account_minimal_test.xml#L125
and https://github.com/odoo/odoo/blob/13.0/addons/account/test/account_minimal_test.xml#L214

This removes the repeated declaration and adds code in tests to load
needed data from the `account` addon.

Before this, tests would fail if some other addon tried to create the
same demo data.

@Tecnativa
TT26079

ping @pedrobaeza @chienandalu 