### PR TITLE
[13.0] account_financial_risk: Add invoice validation allowance field to res.company form

### DIFF
--- a/account_financial_risk/__manifest__.py
+++ b/account_financial_risk/__manifest__.py
@@ -17,6 +17,7 @@
         "views/res_partner_view.xml",
         "wizards/partner_risk_exceeded_view.xml",
         "templates/assets.xml",
+	"views/res_company_view.xml",
     ],
     "installable": True,
     "pre_init_hook": "pre_init_hook",

--- a/account_financial_risk/views/res_company_view.xml
+++ b/account_financial_risk/views/res_company_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_company_form_view" model="ir.ui.view">
+        <field name="name">custom.res.company.form</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='favicon']" position="after">
+                <field name="allow_overrisk_invoice_validation"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This is a pull request to help users select if they want allow invoice validation when financial risk has been exceeded.
During the usage of the module account_financial_risk, I noticed that there was not an easy way to select if a company must allow invoice validation even when financial risk has been exceeded. That is why I added a checkbox in the form of res.company in order to give an easier way to make the selection.
I suggest adding this piece of code since it is already done and fully working.