### PR TITLE
[13.0][IMP] account_credit_control - Consider ToDo lines as left lines

### DIFF
--- a/account_credit_control/models/credit_control_line.py
+++ b/account_credit_control/models/credit_control_line.py
@@ -241,14 +241,15 @@ class CreditControlLine(models.Model):
             )
             lines_to_create.append(vals)
 
-            # when we have lines generated earlier in draft,
-            # on the same level, it means that we have left
-            # them, so they are to be considered as ignored
+            # when we have lines generated earlier in draft
+            # or to_be_sent on the same level, it means that
+            # we have left them, so they are to be considered
+            # as ignored
             previous_drafts = self.search(
                 [
                     ("move_line_id", "=", move_line.id),
                     ("policy_level_id", "=", level.id),
-                    ("state", "=", "draft"),
+                    ("state", "in", ["draft", "to_be_sent"]),
                 ]
             )
             lines_to_write = lines_to_write | previous_drafts


### PR DESCRIPTION
When lines are left as ToDo on the next run new lines for the next level are created. All lines draft or ToDo lines should be processed first before creating a new line.
