### PR TITLE
[13.0][FIX] account_payment_return_financial_risk: Avoid cache miss error in risk_payment_return computed field.

### DIFF
--- a/account_payment_return_financial_risk/models/res_partner.py
+++ b/account_payment_return_financial_risk/models/res_partner.py
@@ -23,6 +23,10 @@ class ResPartner(models.Model):
         "lines related.",
     )
 
+    def _compute_risk_account_amount(self):
+        self.update({"risk_payment_return": 0.0})
+        super()._compute_risk_account_amount()
+
     @api.model
     def _risk_account_groups(self):
         res = super()._risk_account_groups()


### PR DESCRIPTION
cc @Tecnativa
ping @carlosdauden @chienandalu 