### PR TITLE
[FIX] account_credit_control: do not write on action when mailing

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -4,7 +4,7 @@
 # Copyright 2019-2020 Tecnativa
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Account Credit Control',
- 'version': '12.0.3.0.3',
+ 'version': '12.0.3.0.4',
  'author': "Camptocamp,"
            "Odoo Community Association (OCA),"
            "Okia,"

--- a/account_credit_control/migrations/12.0.3.0.4/pre-migration.py
+++ b/account_credit_control/migrations/12.0.3.0.4/pre-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Restore action domain, which was probably polluted.
+
+    This patch release fixes a bug whose result may be stored in database, so
+    although it's still a patch, we need to clear the database, just in case.
+    """
+    action = env.ref("account_credit_control.credit_control_communication_action")
+    action.domain = []

--- a/account_credit_control/wizard/credit_control_emailer.py
+++ b/account_credit_control/wizard/credit_control_emailer.py
@@ -63,7 +63,7 @@ class CreditControlEmailer(models.TransientModel):
         if not communications:
             return {'type': 'ir.actions.act_window_close'}
         action = self.sudo().env.ref(
-            "account_credit_control.credit_control_communication_action")
+            "account_credit_control.credit_control_communication_action").read()[0]
         action['name'] = _('Generated communications')
         action["domain"] = [('id', 'in', communications.ids)]
         return action


### PR DESCRIPTION
Without this patch, the actual action record was overwritten each time communications were mailed, resulting in the "communications" menu being filtered always for last mailings, effectively hiding most of the communications.

@Tecnativa TT28800 TT28823 @chienandalu