### PR TITLE
Break with non present number field on invoice

### DIFF
--- a/account_credit_control/report/report_credit_control_summary.xml
+++ b/account_credit_control/report/report_credit_control_summary.xml
@@ -39,10 +39,7 @@
                         <tr t-foreach="doc.credit_control_line_ids" t-as="l">
                             <t t-if="l.invoice_id">
                                 <td>
-                                    <span t-field="l.invoice_id.number" />
-                                    <t t-if="l.invoice_id.name">
-                                        <span t-field="l.invoice_id.name" />
-                                    </t>
+                                    <span t-field="l.invoice_id.name" />
                                 </td>
                             </t>
                             <t t-if="not l.invoice_id">


### PR DESCRIPTION
There is no more "number" field is v13. replace it by name instead.
or if its provided by another module, please depend on it.