### PR TITLE
[13.0][FIX] Correct URL in account_credit_control

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -15,7 +15,7 @@
     "maintainer": "Camptocamp",
     "category": "Finance",
     "depends": ["base", "account", "mail"],
-    "website": "https://github.com/OCA/account-financial-tools",
+    "website": "https://github.com/OCA/credit-control",
     "data": [
         # Security
         "security/account_security.xml",


### PR DESCRIPTION
Looks like this module was moved from `account-financial-tools` and the `website` URL was never updated.