### PR TITLE
[12.0] FIX account_invoice_overdue_reminder Expected singleton

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -402,7 +402,6 @@ class OverdueReminderStep(models.TransientModel):
         return vals
 
     def check_warnings(self):
-        self.ensure_one()
         for rec in self:
             if rec.company_id != self.env.user.company_id:
                 raise UserError(_(


### PR DESCRIPTION
  File "odoo/addons/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py", line 405, in check_warnings
    self.ensure_one()
  File "odoo/odoo/models.py", line 4768, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: overdue.reminder.step(ID1, ID2)