### PR TITLE
[12.0] FIX account_invoice_overdue_reminder preventing to delete template used by the module

### DIFF
--- a/account_invoice_overdue_reminder/models/__init__.py
+++ b/account_invoice_overdue_reminder/models/__init__.py
@@ -5,3 +5,4 @@ from . import account_invoice
 from . import overdue_reminder_result
 from . import overdue_reminder_action
 from . import account_invoice_overdue_reminder
+from . import mail_template

--- a/account_invoice_overdue_reminder/models/mail_template.py
+++ b/account_invoice_overdue_reminder/models/mail_template.py
@@ -1,0 +1,16 @@
+from odoo import models, exceptions, _
+
+
+class Template(models.Model):
+    _inherit = "mail.template"
+
+    def unlink(self):
+        reminder = self.env.ref(
+            "account_invoice_overdue_reminder.overdue_invoice_reminder_mail_template")
+        for template in self:
+            if template.id == reminder.id:
+                raise exceptions.UserError(_(
+                    "You can't delete Overdue Invoice Reminder, it is needed by the"
+                    " module"
+                ))
+        return super(Template, self).unlink()


### PR DESCRIPTION


Steps:

 - Delete Overdue Invoice Reminder email template
 - Create an old invoice
 - Run reminder wizard

Get
ValueError: External ID not found in the system: account_invoice_overdue_reminder.overdue_invoice_reminder_mail_template