### PR TITLE
[12.0] FIX account_invoice_overdue_reminder to not include too recent invoices.

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -180,10 +180,14 @@ class OverdueReminderStart(models.TransientModel):
                 'Skipping customer %s that has no_overdue_reminder=True',
                 commercial_partner.display_name)
             return False
+        today = fields.Date.context_today(self)
+        limit_date = today
+        if self.start_days:
+            limit_date -= relativedelta(days=self.start_days)
         invs = self.env['account.invoice'].search(
             base_domain + [
                 ('commercial_partner_id', '=', commercial_partner.id),
-                ('date_due', '<', fields.Date.context_today(self))])
+                ('date_due', '<', limit_date)])
         assert invs
         # Check min interval
         if any([


### PR DESCRIPTION
Steps:

 - Create and validate an invoice with date = 10 days ago
 - Create and validate an invoice with date = yesterday
 - Run Overdue Invoice Remind setting Trigger Delay = 5 days

Observed: the second invoice is included

Desired: the second invoice is not included