### PR TITLE
[14.0] [FIX] sale_financial_risk: Don't use deprecated `account.move` method `post()`

### DIFF
--- a/sale_financial_risk/tests/test_partner_sale_risk.py
+++ b/sale_financial_risk/tests/test_partner_sale_risk.py
@@ -85,7 +85,7 @@ class TestPartnerSaleRisk(SavepointCase):
         self.assertAlmostEqual(self.partner.risk_invoice_draft, 100.0)
         self.assertAlmostEqual(self.partner.risk_sale_order, 0)
         invoice = self.sale_order.invoice_ids
-        invoice.with_context(bypass_risk=True).post()
+        invoice.with_context(bypass_risk=True).action_post()
         self.assertAlmostEqual(self.partner.risk_sale_order, 0)
         self.assertAlmostEqual(self.partner.risk_invoice_draft, 0.0)
         self.assertAlmostEqual(self.partner.risk_invoice_open, 100.0)


### PR DESCRIPTION
`account.move` `post()` [is deprecated](https://github.com/odoo/odoo/blob/f964b761eae32016e36dd9d39cc2c35fc2270eba/addons/account/models/account_move.py#L2403-L2407) since Odoo 14.0 and issues a [warning](https://app.travis-ci.com/github/OCA/credit-control/jobs/527708361#L1220) in the logs when used.