### PR TITLE
[12.0][IMP] account_invoice_overdue_reminder get invoice generic report

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -469,8 +469,7 @@ class OverdueReminderStep(models.TransientModel):
         mvals.pop('attachment_ids', None)
         mvals.pop('attachments', None)
         mail = self.env['mail.mail'].create(mvals)
-        inv_report = self.env['ir.actions.report']._get_report_from_name(
-            'account.report_invoice_with_payments')
+        inv_report = self.env.ref('account.account_invoices')
         if self.company_id.overdue_reminder_attach_invoice:
             attachment_ids = []
             for inv in self.invoice_ids:


### PR DESCRIPTION
Use a more generic way to get current invoice report, useful when there is an alternative report installed.