### PR TITLE
[IMP] account_invoice_overdue_reminder: allow to remove some undesired invoices on the fly during reminder process

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard_view.xml
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard_view.xml
@@ -67,7 +67,7 @@
         <form>
             <group name="main" col="4">
                 <field name="commercial_partner_id"/>
-                <field name="counter"/>
+                <field name="counter" force_save="1"/>
                 <field name="partner_id" domain="[('id', 'child_of', commercial_partner_id)]"/>
                 <field name="partner_phone" widget="phone"/>
                 <field name="partner_email" widget="email"/>
@@ -84,7 +84,7 @@
             </group>
             <group name="invoices">
                 <field name="invoice_ids" nolabel="1" context="{'form_view_ref': 'account.invoice_form'}">
-                    <tree default_order="date_invoice">
+                    <tree default_order="date_invoice" create="false">
                         <field name="partner_id" string="Invoicing Contact"/>
                         <field name="number"/>
                         <field name="date_invoice"/>
@@ -120,6 +120,17 @@
             </group>
             <group name="mail" attrs="{'invisible': [('reminder_type', '!=', 'mail')]}">
                 <field name="mail_cc_partner_ids" domain="[('id', 'child_of', commercial_partner_id), ('id', '!=', partner_id), ('email', '!=', False)]" widget="many2many_tags"/>
+                <field name="display_button_recompute_mail_info" invisible="1"/>
+                <div
+                    class="alert alert-warning" role="alert" colspan="2"
+                    attrs="{'invisible': [('display_button_recompute_mail_info', '=', False)]}"
+                >Click on <button
+                        string="this link"
+                        type="object"
+                        name="button_compute_mail_info"
+                        class="oe_link"
+                    />to recompute the mail informations
+                </div>
                 <field name="mail_subject"/>
                 <field name="mail_body" colspan="2" nolabel="1"/>
             </group>


### PR DESCRIPTION
**Summary**
This PR improve the module ``account_invoice_overdue_reminder`` to allow user to remove manually one or many invoices. This will recompute automatically the field ``counter``, and let user manually regenerate body and subject mail. (if reminder type is email)

**Use Case**
- Your customer has several invoices to pay. For one invoice, there is a pending conflict (customer think that the delivered products or the service is not ok, ...) You want to send a reminder without the conflictual invoice.
- Your customer has several invoices to pay. One of the invoice has been confirmed and sent late from your part. So you don't want to send a reminder for this invoice, but for the others.

**Screenshots**

**Step 1** : The wizard display all the invoices. The user can remove on or many invoices.

![image](https://user-images.githubusercontent.com/3407482/154070810-a83d939f-c766-4112-9baf-37d17cd61931.png)

**Step2 ** : when an invoice is removed, counter is refreshed and an message is displayed to recompute email info. (title & body)

![image](https://user-images.githubusercontent.com/3407482/154071021-b00b7969-0f4c-4478-bcf7-5703109fd8cb.png)

**Step 3** : Once clicked, the email info are updated. 

![image](https://user-images.githubusercontent.com/3407482/154071055-0b11c4e3-fc1a-4b8a-9f32-d0f956ba2e6b.png)

**Technical point**
- ``counter`` can be recomputed on the fly with a classic ``onchange`` function. However, recompute body is not possible in an 
- ``onchange`` function, because ``self.id`` is ``Newid`` in this context, making not possible the call of the function ``_render_template(..., res_id)``. For that reason a button is displayed.

Perhaps such workaround may be removed in more recent version of Odoo (with the refactor of onchange / depends core features). 