### PR TITLE
[14.0][UPD] sale_financial_risk: Added a compute field to display the customer remaining risk amount in SO

### DIFF
--- a/sale_financial_risk/__manifest__.py
+++ b/sale_financial_risk/__manifest__.py
@@ -1,13 +1,14 @@
+# Update 2022 Ooops - Ashish Hirpara
 # Copyright 2016-2020 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
     "name": "Sale Financial Risk",
     "summary": "Manage partner risk in sales orders",
-    "version": "14.0.1.3.0",
+    "version": "14.0.1.3.1",
     "category": "Sales Management",
     "license": "AGPL-3",
-    "author": "Tecnativa, Odoo Community Association (OCA)",
+    "author": "Ashish Hirpara, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/credit-control",
     "depends": ["sale", "account_financial_risk"],
     "data": [

--- a/sale_financial_risk/models/sale.py
+++ b/sale_financial_risk/models/sale.py
@@ -1,3 +1,4 @@
+# Update 2022 Ooops - Ashish Hirpara
 # Copyright 2016-2020 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
@@ -7,6 +8,20 @@ from odoo.tools import float_round
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
+
+    remaining_risk = fields.Float(
+        "Remaining Customer Financial Risk", compute="_compute_remaining_risk"
+    )
+
+    @api.depends("amount_total", "partner_id", "partner_id.risk_total")
+    def _compute_remaining_risk(self):
+        for record in self:
+            if record.partner_id:
+                record.remaining_risk = (
+                    record.partner_id.risk_total - record.amount_total
+                )
+            else:
+                record.remaining_risk = 0
 
     def evaluate_risk_message(self, partner):
         self.ensure_one()

--- a/sale_financial_risk/readme/CONTRIBUTORS.rst
+++ b/sale_financial_risk/readme/CONTRIBUTORS.rst
@@ -7,3 +7,8 @@
 * Agathe Mollé <agathe.molle@savoirfairelinux.com>
 
 * Ugne Sinkeviciene <ugne@versada.eu>
+
+
+* `Ooops <https://www.ooops404.com/>`_:
+
+  * Ashish Hirpara <https://ashish-hirpara.com>

--- a/sale_financial_risk/readme/DESCRIPTION.rst
+++ b/sale_financial_risk/readme/DESCRIPTION.rst
@@ -4,4 +4,4 @@ Adds a new risk amount field in sale order line to compute risk based on the
 difference between ordered quantity (or delivered in some cases) and invoiced
 quantity.
 
-If any limit is exceed the partner gets forbidden to confirm sale orders.
+If any limit is exceed the partner gets forbidden to confirm sale orders and you can see the available limit of the customer under the sale order.

--- a/sale_financial_risk/views/sale_financial_risk_view.xml
+++ b/sale_financial_risk/views/sale_financial_risk_view.xml
@@ -13,4 +13,24 @@
             </pivot>
         </field>
     </record>
+
+    <record id="financial_risk_sale_order_form_view" model="ir.ui.view">
+        <field name="name">financial.risk.sale.order.form.view</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <field name="amount_untaxed" position="before">
+                <field
+                    name="remaining_risk"
+                    style="color:red;"
+                    attrs="{'invisible':[('remaining_risk','&gt;=', 0)]}"
+                />
+                <field
+                    name="remaining_risk"
+                    attrs="{'invisible':[('remaining_risk','&lt;', 0)]}"
+                />
+
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Added a compute field to display the customer's remaining risk amount in the Sale Order. So the user will be aware of the remaining amount of financial risk when adding a product to the SO line. 

Updated behavior:

Added a "Remaining customer financial risk" calculated field above the total calculation.