### PR TITLE
[14.0][FIX] account_financial_risk: inherit action_post instead of _post

### DIFF
--- a/account_financial_risk/tests/test_account_financial_risk.py
+++ b/account_financial_risk/tests/test_account_financial_risk.py
@@ -126,7 +126,7 @@ class TestPartnerFinancialRisk(SavepointCase):
         invoice2 = self.invoice.copy({"partner_id": self.invoice_address.id})
         self.assertAlmostEqual(self.partner.risk_invoice_draft, 550.0)
         self.assertAlmostEqual(self.partner.risk_invoice_unpaid, 550.0)
-        wiz_dic = invoice2._post()
+        wiz_dic = invoice2.action_post()
         wiz = self.env[wiz_dic["res_model"]].browse(wiz_dic["res_id"])
         self.assertEqual(wiz.exception_msg, "Financial risk exceeded.\n")
         self.partner.risk_invoice_unpaid_limit = 0.0
@@ -135,7 +135,7 @@ class TestPartnerFinancialRisk(SavepointCase):
         self.assertIn(self.partner, unrisk_partners)
         self.partner.risk_invoice_open_limit = 300.0
         invoice2.invoice_date_due = fields.Date.today()
-        wiz_dic = invoice2._post()
+        wiz_dic = invoice2.action_post()
         wiz = self.env[wiz_dic["res_model"]].browse(wiz_dic["res_id"])
         self.assertEqual(
             wiz.exception_msg, "This invoice exceeds the open invoices risk.\n"
@@ -144,7 +144,7 @@ class TestPartnerFinancialRisk(SavepointCase):
         self.partner.risk_invoice_draft_include = False
         self.partner.risk_invoice_open_include = True
         self.partner.credit_limit = 900.0
-        wiz_dic = invoice2._post()
+        wiz_dic = invoice2.action_post()
         wiz = self.env[wiz_dic["res_model"]].browse(wiz_dic["res_id"])
         self.assertEqual(
             wiz.exception_msg, "This invoice exceeds the financial risk.\n"
@@ -189,7 +189,7 @@ class TestPartnerFinancialRisk(SavepointCase):
                 }
             )
         )
-        self.move._post()
+        self.move.action_post()
         self.assertAlmostEqual(self.partner.risk_account_amount, 100.0)
         line = self.move.line_ids.filtered(lambda x: x.debit != 0.0)
         line.date_maturity = "2017-01-01"
@@ -210,7 +210,7 @@ class TestPartnerFinancialRisk(SavepointCase):
         new._compute_risk_account_amount()
 
     def test_batch_invoice_confirm(self):
-        self.invoice._post()
+        self.invoice.action_post()
         line = self.invoice.line_ids.filtered(lambda x: x.debit != 0.0)
         line.date_maturity = "2017-01-01"
         self.partner.risk_invoice_unpaid_include = True
@@ -222,7 +222,7 @@ class TestPartnerFinancialRisk(SavepointCase):
             .create({})
         )
         with self.assertRaises(ValidationError):
-            invoice2._post()
+            invoice2.action_post()
             validate_wiz.validate_move()
         self.assertEqual(invoice2.state, "draft")
 


### PR DESCRIPTION
`_post` method return records and other modules could use it to perform any actions on this.

Based implementation from version `13.0` [here](https://github.com/OCA/credit-control/blob/2846f7f74ffab2e739f709e9e940d2dfa873c0d7/account_financial_risk/models/account_invoice.py#L62) that uses **post** method and the new mechanism in `14.0` in `account` module, is expected to inherit `action_post` insted of `_post` also seeing [this](https://github.com/odoo/odoo/blob/5b099bf6135b2ff517078d1839b513da7830f718/addons/account/models/account_move.py#L2575-L2581)

note: without this changes `account_financial_risk` will never show wizard because `_post` is encapsulated in `action_post` that is not interested in value returned from it
see https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_move.py#L2716-L2718