### PR TITLE
[13.0][FIX] account_credit_control: Typo error _sql_constraint instead of _sql_constraints

### DIFF
--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -264,7 +264,7 @@ class CreditControlPolicyLevel(models.Model):
         string="Custom Message after details", translate=True
     )
 
-    _sql_constraint = [
+    _sql_constraints = [
         ("unique level", "UNIQUE (policy_id, level)", "Level must be unique per policy")
     ]
 


### PR DESCRIPTION
@Tecnativa