### PR TITLE
[14.0][FIX] account_credit_control: constraints name no spaces

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Credit Control",
-    "version": "14.0.1.1.0",
+    "version": "14.0.1.2.0",
     "author": "Camptocamp,"
     "Odoo Community Association (OCA),"
     "Okia,"

--- a/account_credit_control/migrations/14.0.1.2.0/pre-migration.py
+++ b/account_credit_control/migrations/14.0.1.2.0/pre-migration.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Abraham Anes - Studio73
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_xmlids(
+        env.cr,
+        [
+            (
+                "account_credit_control."
+                "constraint_credit_control_policy_level_unique level",
+                "account_credit_control."
+                "constraint_credit_control_policy_level_unique_level",
+            ),
+        ],
+    )
+    env.cr.execute(
+        """
+        ALTER TABLE credit_control_policy_level
+        DROP CONSTRAINT IF EXISTS "credit_control_policy_level_unique level"
+        """
+    )

--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -257,7 +257,7 @@ class CreditControlPolicyLevel(models.Model):
     )
 
     _sql_constraints = [
-        ("unique level", "UNIQUE (policy_id, level)", "Level must be unique per policy")
+        ("unique_level", "UNIQUE (policy_id, level)", "Level must be unique per policy")
     ]
 
     @api.constrains("level", "computation_mode")


### PR DESCRIPTION
Odoo doesn't allow spaces in external IDs and all `sql_constrains` generate an external ID.

Here is the runboat error: https://runboat.odoo-community.org/api/v1/builds/b5dd9f999-992d-49ff-9377-276f13439c7a/init-log

```
2022-05-09 00:46:54,790 52 ERROR b5dd9f999-992d-49ff-9377-276f13439c7a odoo.sql_db: bad query: 
            INSERT INTO ir_model_data (module, name, model, res_id, noupdate)
            VALUES ('account_credit_control', 'constraint_credit_control_policy_level_unique level', 'ir.model.constraint', 911, false)
            ON CONFLICT (module, name)
            DO UPDATE SET (model, res_id, write_date) =
                (EXCLUDED.model, EXCLUDED.res_id, now() at time zone 'UTC')
                
        
ERROR: new row for relation "ir_model_data" violates check constraint "ir_model_data_name_nospaces"
DETAIL:  Failing row contains (13578, null, 2022-05-09 00:46:54.151204, 2022-05-09 00:46:54.151204, null, f, constraint_credit_control_policy_level_unique level, account_credit_control, ir.model.constraint, 911).
 
2022-05-09 00:46:54,791 52 ERROR b5dd9f999-992d-49ff-9377-276f13439c7a odoo.addons.base.models.ir_model: Failed to insert ir_model_data
('account_credit_control', 'constraint_credit_control_policy_level_unique level', 'ir.model.constraint', 911, False) 
2022-05-09 00:46:54,793 52 WARNING b5dd9f999-992d-49ff-9377-276f13439c7a odoo.modules.loading: Transient module states were reset 
2022-05-09 00:46:54,806 52 ERROR b5dd9f999-992d-49ff-9377-276f13439c7a odoo.modules.registry: Failed to load registry 
2022-05-09 00:46:54,806 52 CRITICAL b5dd9f999-992d-49ff-9377-276f13439c7a odoo.service.server: Failed to initialize database `b5dd9f999-992d-49ff-9377-276f13439c7a`. 
Traceback (most recent call last):
  File "/opt/odoo/odoo/service/server.py", line 1201, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/opt/odoo/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/odoo/modules/loading.py", line 461, in load_modules
    loaded_modules, update_module, models_to_check)
  File "/opt/odoo/odoo/modules/loading.py", line 349, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/opt/odoo/odoo/modules/loading.py", line 199, in load_module_graph
    registry.init_models(cr, model_names, {'module': package.name}, new_install)
  File "/opt/odoo/odoo/modules/registry.py", line 411, in init_models
    env['ir.model.constraint']._reflect_constraints(model_names)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1574, in _reflect_constraints
    self._reflect_model(self.env[model_name])
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1598, in _reflect_model
    self.env['ir.model.data']._update_xmlids(data_list)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 2038, in _update_xmlids
    self.env.cr.execute(query, [arg for row in sub_rows for arg in row])
  File "<decorator-gen-3>", line 2, in execute
  File "/opt/odoo/odoo/sql_db.py", line 101, in check
    return f(self, *args, **kwargs)
  File "/opt/odoo/odoo/sql_db.py", line 298, in execute
    res = self._obj.execute(query, params)
psycopg2.IntegrityError: new row for relation "ir_model_data" violates check constraint "ir_model_data_name_nospaces"
DETAIL:  Failing row contains (13578, null, 2022-05-09 00:46:54.151204, 2022-05-09 00:46:54.151204, null, f, constraint_credit_control_policy_level_unique level, account_credit_control, ir.model.constraint, 911).

```