### PR TITLE
[FIX] account_credit_control: Allow to use run on multicompany environments

### DIFF
--- a/account_credit_control/models/credit_control_communication.py
+++ b/account_credit_control/models/credit_control_communication.py
@@ -114,15 +114,15 @@ class CreditControlCommunication(models.Model):
     ):
         """ Return credit lines related to a partner and a policy level """
         cr_line_obj = self.env["credit.control.line"]
-        cr_lines = cr_line_obj.search(
-            [
-                ("id", "in", line_ids),
-                ("partner_id", "=", partner_id),
-                ("policy_level_id", "=", level_id),
-                ("currency_id", "=", currency_id),
-                ("company_id", "=", company_id),
-            ]
-        )
+        domain = [
+            ("id", "in", line_ids),
+            ("partner_id", "=", partner_id),
+            ("policy_level_id", "=", level_id),
+            ("currency_id", "=", currency_id),
+        ]
+        if company_id:
+            domain.append(("company_id", "=", company_id))
+        cr_lines = cr_line_obj.search(domain)
         return cr_lines
 
     @api.model

--- a/account_credit_control/models/credit_control_run.py
+++ b/account_credit_control/models/credit_control_run.py
@@ -132,14 +132,15 @@ class CreditControlRun(models.Model):
 
             if policy.do_nothing:
                 continue
-            (
-                policy_manual_lines,
-                policy_lines_generated,
-                policy_report,
-            ) = policy._generate_credit_lines(self, {"run_id": self.id})
-            manually_managed_lines |= policy_manual_lines
-            generated |= policy_lines_generated
-            report += policy_report
+            for company in self.company_id or self.env.companies:
+                (
+                    policy_manual_lines,
+                    policy_lines_generated,
+                    policy_report,
+                ) = policy._generate_credit_lines(self, company, {"run_id": self.id})
+                manually_managed_lines |= policy_manual_lines
+                generated |= policy_lines_generated
+                report += policy_report
 
         vals = {
             "state": "done",

--- a/account_credit_control/tests/test_credit_control_run.py
+++ b/account_credit_control/tests/test_credit_control_run.py
@@ -132,6 +132,30 @@ class TestCreditControlRun(TransactionCase):
         regex_result = re.match(report_regex, control_run.report)
         self.assertIsNotNone(regex_result)
 
+    def test_generate_credit_lines_multicompany(self):
+        """
+        Test the method generate_credit_lines
+        """
+        control_run = self.env["credit.control.run"].create(
+            {
+                "date": fields.Date.today(),
+                "policy_ids": [(6, 0, [self.policy.id])],
+                "company_id": False,
+            }
+        )
+
+        control_run.with_context(lang="en_US").generate_credit_lines()
+
+        self.assertEqual(len(self.invoice.credit_control_line_ids), 1)
+        self.assertEqual(control_run.state, "done")
+
+        report_regex = (
+            r'<p>Policy "<b>%s</b>" has generated <b>'
+            r"\d+ Credit Control Lines.</b><br></p>" % self.policy.name
+        )
+        regex_result = re.match(report_regex, control_run.report)
+        self.assertIsNotNone(regex_result)
+
     def test_multi_credit_control_run(self):
         """
         Generate several control run


### PR DESCRIPTION
With the change, run works properly if no company is set (generated for all visible companies)