### PR TITLE
[13.0][IMP] account_invoice_overdue_reminder: add method to get reminder template

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -503,6 +503,9 @@ class OverdueReminderStep(models.TransientModel):
                 action = self.goto_list_view()
             return action
 
+    def _get_overdue_invoice_reminder_template(self):
+        return MOD + ".overdue_invoice_reminder_mail_template"
+
     def validate_mail(self):
         self.ensure_one()
         iao = self.env["ir.attachment"]
@@ -514,7 +517,7 @@ class OverdueReminderStep(models.TransientModel):
             raise UserError(_("Mail subject is empty."))
         if not self.mail_body:
             raise UserError(_("Mail body is empty."))
-        xmlid = MOD + ".overdue_invoice_reminder_mail_template"
+        xmlid = self._get_overdue_invoice_reminder_template()
         mvals = self.env.ref(xmlid).generate_email(
             self.id, ["email_from", "email_to", "partner_to", "reply_to"]
         )

--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -367,7 +367,7 @@ class OverdueReminderStep(models.TransientModel):
         commercial_partner = self.env["res.partner"].browse(
             vals["commercial_partner_id"]
         )
-        xmlid = MOD + ".overdue_invoice_reminder_mail_template"
+        xmlid = self._get_overdue_invoice_reminder_template()
         mail_tpl = self.env.ref(xmlid)
         mail_tpl_lang = mail_tpl.with_context(lang=commercial_partner.lang or "en_US")
         mail_subject = mail_tpl_lang._render_template(


### PR DESCRIPTION
In case you want to use more than one different templates for the reminders it is more convenient to have a dedicated method.

CC @ForgeFlow