### PR TITLE
[13.0][IMP] account_invoice_overdue_reminder: handle mail partner_ids

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -524,6 +524,8 @@ class OverdueReminderStep(models.TransientModel):
         cc_list = [p.email for p in self.mail_cc_partner_ids if p.email]
         if mvals.get("email_cc"):
             cc_list.append(mvals["email_cc"])
+        if mvals.get("partner_ids"):
+            mvals["recipient_ids"] = mvals.pop("partner_ids")
         mvals.update(
             {
                 "subject": self.mail_subject,


### PR DESCRIPTION
When generating the recipients of a mail template, if multiple partners are passed as "partner_ids" in values, odoo will change the "partner_to" key and add the "partner_ids" key. (https://github.com/odoo/odoo/blob/5a911f7cab346c97ebf24d7667a20c7b9a0619b2/addons/mail/models/mail_template.py#L366)
In cases where the email is created and send directly using the send_mail() method odoo already takes care of converting the "partner_ids" key as the "recipient_ids" of the mail (https://github.com/odoo/odoo/blob/5a911f7cab346c97ebf24d7667a20c7b9a0619b2/addons/mail/models/mail_template.py#L493)

CC @ForgeFlow