### PR TITLE
[13.0][IMP] account_invoice_overdue_reminder: add the body mail to the chatter message

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -531,6 +531,7 @@ class OverdueReminderStep(models.TransientModel):
                 "email_cc": ", ".join(cc_list),
                 "model": "res.partner",
                 "res_id": self.commercial_partner_id.id,
+                "body": self.mail_body,
             }
         )
         mvals.pop("attachment_ids", None)


### PR DESCRIPTION
If it's not passed a body mail, the chatter message will not have a body.

CC @ForgeFlow