### PR TITLE
[13.0][IMP]account_invoice_overdue_reminder: Set default values

### DIFF
--- a/account_invoice_overdue_reminder/__init__.py
+++ b/account_invoice_overdue_reminder/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizard
+from .hooks import pre_init_hook

--- a/account_invoice_overdue_reminder/__manifest__.py
+++ b/account_invoice_overdue_reminder/__manifest__.py
@@ -29,4 +29,5 @@
     ],
     "installable": True,
     "application": True,
+    "pre_init_hook": "pre_init_hook",
 }

--- a/account_invoice_overdue_reminder/hooks.py
+++ b/account_invoice_overdue_reminder/hooks.py
@@ -1,0 +1,33 @@
+# Copyright 2022 ForgeFlow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):
+    _logger.info(
+        "Pre-creating column overdue_reminder_last_date for table account_move"
+    )
+    cr.execute(
+        """
+        ALTER TABLE account_move
+        ADD COLUMN IF NOT EXISTS overdue_reminder_last_date Date;
+        """
+    )
+    _logger.info("Pre-creating column overdue_reminder_counter for table account_move")
+    cr.execute(
+        """
+        ALTER TABLE account_move
+        ADD COLUMN IF NOT EXISTS overdue_reminder_counter INTEGER DEFAULT 0;
+        ALTER TABLE account_move ALTER COLUMN overdue_reminder_counter DROP DEFAULT;
+        """
+    )
+    _logger.info("Pre-creating column no_overdue_reminder for table account_move")
+    cr.execute(
+        """
+        ALTER TABLE account_move
+        ADD COLUMN IF NOT EXISTS no_overdue_reminder BOOL DEFAULT False;
+        ALTER TABLE account_move ALTER COLUMN no_overdue_reminder DROP DEFAULT;
+        """
+    )


### PR DESCRIPTION
When installing the module for a database with a large amount of account.move the performance will be very slow. At first, the overdue_reminder_last_date and the overdue_reminder_counter fields don't need to be computed as it will only make sense to be used in the future.
cc @ForgeFlow