### PR TITLE
[15.0][FIX]sale_financial_risk: Invoice from Sales Order should show risk confirmation wizard

### DIFF
--- a/sale_financial_risk/models/__init__.py
+++ b/sale_financial_risk/models/__init__.py
@@ -2,3 +2,4 @@ from . import payment
 from . import res_partner
 from . import sale
 from . import res_config_settings
+from . import account_invoice

--- a/sale_financial_risk/models/account_invoice.py
+++ b/sale_financial_risk/models/account_invoice.py
@@ -1,0 +1,31 @@
+# Copyright 2016-2018 Tecnativa - Carlos Dauden
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def action_post(self):
+        invoice, exception_msg = self._first_invoice_exception_msg()
+        if (
+            exception_msg
+            and self.env.context.get("active_model", False)
+            and self.env.context.get("active_model", False) == "sale.order"
+        ):
+            # Active active_model is not False if we come from the sales order invoices
+            # button.
+            return (
+                self.env["partner.risk.exceeded.wiz"]
+                .create(
+                    {
+                        "exception_msg": exception_msg,
+                        "partner_id": invoice.partner_id.commercial_partner_id.id,
+                        "origin_reference": "{},{}".format("account.move", invoice.id),
+                        "continue_method": "action_post",
+                    }
+                )
+                .action_show()
+            )
+        return super().action_post()


### PR DESCRIPTION
If you go to a sales order and then to the invoices from the button and you try to validate the invoice you currently get the exception message, but you are not able to continue with the validation even if you are a partner risk manager.

However, if you go to the same invoice from the accounting menu you will be able to validate the invoice, because the context is not passed. This sentence here in the account_financial_risk module is not correct when you come from sales orders: https://github.com/OCA/credit-control/blob/15.0/account_financial_risk/models/account_invoice.py#L102

In my opinion it should work the same way, as you are trying to validate the same invoice. WDYT?

cc @ForgeFlow @MiquelRForgeFlow 

