### PR TITLE
[13.0][FIX] account_invoice_overdue_reminder: avoid error when migrating

### DIFF
--- a/account_invoice_overdue_reminder/migrations/13.0.1.0.0/pre-migration.py
+++ b/account_invoice_overdue_reminder/migrations/13.0.1.0.0/pre-migration.py
@@ -7,6 +7,9 @@ from openupgradelib import openupgrade
 
 @openupgrade.migrate()
 def migrate(env, version):
+    openupgrade.lift_constraints(
+        env.cr, "account_invoice_overdue_reminder", "invoice_id"
+    )
     openupgrade.rename_columns(
         env.cr, {"account_invoice_overdue_reminder": [("invoice_id", None)]}
     )


### PR DESCRIPTION
solves:
```yml
odoo.modules.loading: Loading module account_invoice_overdue_reminder (66/144) 
odoo.modules.registry: module account_invoice_overdue_reminder: creating or updating database tables 
odoo.models: Storing computed values of account.move.overdue_reminder_last_date 
odoo.models: Storing computed values of account.move.overdue_reminder_counter 
odoo.sql_db: bad query: ALTER TABLE "account_invoice_overdue_reminder" ADD FOREIGN KEY ("invoice_id") REFERENCES "account_move"("id") ON DELETE cascade
ERROR: insert or update on table "account_invoice_overdue_reminder" violates foreign key constraint "account_invoice_overdue_reminder_invoice_id_fkey"
DETAIL:  Key (invoice_id)=(2044) is not present in table "account_move".
 
odoo.modules.loading: Transient module states were reset 
odoo.modules.registry: Failed to load registry 
```