### PR TITLE
[15.0][FIX] account_financial_risk: date_credit_limit view in editin mode

### DIFF
--- a/account_financial_risk/views/res_partner_view.xml
+++ b/account_financial_risk/views/res_partner_view.xml
@@ -194,13 +194,17 @@
                                 options="{'currency_field': 'risk_currency_id'}"
                                 attrs="{'readonly': [('risk_allow_edit', '=', False)]}"
                             />
-                            <span
+                            <div
                                 attrs="{'invisible': [('date_credit_limit', '=', False)]}"
                             >
-                                (
-                            <field name="date_credit_limit" widget="date" nolabel="1" />
-                                )
-                            </span>
+                                <span class="oe_read_only">(</span>
+                                <field
+                                    name="date_credit_limit"
+                                    widget="date"
+                                    nolabel="1"
+                                />
+                                <span class="oe_read_only">)</span>
+                            </div>
                         </div>
                         <field
                             name="credit_policy"


### PR DESCRIPTION
The view of the date_credit_limit field is fixed. 
Below you can see a screenshot in edit mode and in readonly mode:
![edition_mode](https://user-images.githubusercontent.com/101106685/200296504-a836b5a3-6365-42f6-a32f-c2e957244d40.png)
![readonly_mode](https://user-images.githubusercontent.com/101106685/200296505-97611345-4556-45ee-a20b-3eb639f9be8a.png)


This fix comes from the PR: #227 