### PR TITLE
[14.0][FIX] account_invoice_overdue_reminder: No ensure_one in check_warnings

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -476,7 +476,6 @@ class OverdueReminderStep(models.TransientModel):
         return vals
 
     def check_warnings(self):
-        self.ensure_one()
         for rec in self:
             if rec.company_id != self.env.company:
                 raise UserError(


### PR DESCRIPTION
As the self.ensure_one() is meant to ensure that a function can only be applied on exactly one record of a recordset and the function "check_warnings" still iterates over all records (not returning anything but really just checking) it doesn't make sense to keep this piece of code.
Additionally it causes issues when trying to work on multiple records.