### PR TITLE
[15.0][FIX] account_financial_risk: Access error when displaying the partner risk exceeded wizard

### DIFF
--- a/account_financial_risk/wizards/parner_risk_exceeded.py
+++ b/account_financial_risk/wizards/parner_risk_exceeded.py
@@ -13,7 +13,9 @@ class PartnerRiskExceededWiz(models.TransientModel):
     )
     exception_msg = fields.Text(readonly=True)
     origin_reference = fields.Reference(
-        lambda self: [(m.model, m.name) for m in self.env["ir.model"].search([])],
+        lambda self: [
+            (m.model, m.name) for m in self.env["ir.model"].sudo().search([])
+        ],
         string="Object",
     )
     continue_method = fields.Char()


### PR DESCRIPTION
I am getting this error when trying to confirm a sales order with a use with no privileges:

![Peek 2022-11-11 13-31](https://user-images.githubusercontent.com/19620251/201341173-f2ca2468-a1b7-434a-bcdf-ee99b2e49842.gif)

cc @ForgeFlow

Currently, the only solution is to modify this rule: https://github.com/odoo/odoo/blob/15.0/odoo/addons/base/security/ir.model.access.csv#L16