### PR TITLE
[FIX] account_invoice_overdue_reminder : replace user id by user name (get with sudo)

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -72,7 +72,7 @@ class OverdueReminderStart(models.TransientModel):
                 'journal_id': journal.id,
                 'last_entry_date': last and last.date or False,
                 'last_entry_create_date': last and last.create_date or False,
-                'last_entry_create_uid': last and last.create_uid.id or False,
+                'last_entry_create_user_name': last and last.create_uid.sudo().name or False,
                 }
             payments.append((0, 0, vals))
         res.update({
@@ -261,8 +261,8 @@ class OverdueReminderStartPayment(models.TransientModel):
         string='Last Entry', readonly=True)
     last_entry_create_date = fields.Datetime(
         string='Last Entry Created on', readonly=True)
-    last_entry_create_uid = fields.Many2one(
-        'res.users', string='Last Entry Created by', readonly=True)
+    last_entry_create_user_name = fields.Char(
+        string='Last Entry Created by', readonly=True)
 
 
 class OverdueReminderStep(models.TransientModel):

--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard_view.xml
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard_view.xml
@@ -35,7 +35,7 @@
                         <field name="journal_id"/>
                         <field name="last_entry_date"/>
                         <field name="last_entry_create_date"/>
-                        <field name="last_entry_create_uid"/>
+                        <field name="last_entry_create_user_name"/>
                     </tree>
                 </field>
                 <div name="up_to_date">


### PR DESCRIPTION
To avoid having error access if the user of the last entry is not accessible by the current user

**Step to reproduce**

- Use this module in a multi company context.
- user A create an entry in the journal then switch the company
- user B want to use the module "overdue reminder". 
- An error is raised, because User B can not read the name of user B.