### PR TITLE
[14.0][FIX] account_financial_risk - adapt exception msg to multi company

### DIFF
--- a/account_financial_risk/models/account_invoice.py
+++ b/account_financial_risk/models/account_invoice.py
@@ -64,12 +64,12 @@ class AccountMove(models.Model):
         Method used to return the first invoice with exception message.
         """
         ret = False, False
-        if (
-            self.env.context.get("bypass_risk", False)
-            or self.company_id.allow_overrisk_invoice_validation
-        ):
+        if self.env.context.get("bypass_risk", False):
             return ret
-        for invoice in self.filtered(lambda x: x.move_type == "out_invoice"):
+        for invoice in self.filtered(
+            lambda x: x.move_type == "out_invoice"
+            and not x.company_id.allow_overrisk_invoice_validation
+        ):
             exception_msg = invoice.risk_exception_msg()
             if exception_msg:
                 ret = invoice, exception_msg


### PR DESCRIPTION
Running the account's cron "Account; Post draft entries with auto_post set to True up to today" on a multi companies database, we got an Expected singleton error:

`ValueError: <class 'ValueError'>: "Expected singleton: res.company(1, 2)" while evaluating 'model._autopost_draft_entries()'`

that we traced back to this line.