### PR TITLE
[FIX] 14.0 sale_financial_risk remove dispensable orderby

### DIFF
--- a/sale_financial_risk/models/res_partner.py
+++ b/sale_financial_risk/models/res_partner.py
@@ -39,7 +39,6 @@ class ResPartner(models.Model):
             domain=self._get_risk_sale_order_domain(),
             fields=["risk_partner_id", "company_id", "risk_amount"],
             groupby=["risk_partner_id", "company_id"],
-            orderby="id",
             lazy=False,
         )
         for group in orders_group:


### PR DESCRIPTION
That could create a psycopg2.InternalError: could not find pathkey item to sort

Since the order is not needed here it may be easier to just not use it