### PR TITLE
[14.0][IMP] account_credit_control: Add details (table) to communication mail template

### DIFF
--- a/account_credit_control/README.rst
+++ b/account_credit_control/README.rst
@@ -114,6 +114,7 @@ Contributors
   * Pedro M. Baeza
   * Jairo Llopis
   * João Marques
+  * Víctor Martínez
 
 * Enric Tobella <etobella@creublanca.es>
 * Naglis Jonaitis (Versada UAB) <naglis@versada.eu>

--- a/account_credit_control/data/data.xml
+++ b/account_credit_control/data/data.xml
@@ -59,6 +59,7 @@
 
             Best regards
         </field>
+        <field name="mail_show_invoice_detail" eval="True" />
         <field
             name="custom_mail_text"
         ><![CDATA[
@@ -88,6 +89,7 @@
 
             Best regards
         </field>
+        <field name="mail_show_invoice_detail" eval="True" />
         <field
             name="custom_mail_text"
         ><![CDATA[
@@ -119,6 +121,7 @@
 
             Best regards
         </field>
+        <field name="mail_show_invoice_detail" eval="True" />
         <field
             name="custom_mail_text"
         ><![CDATA[
@@ -155,6 +158,7 @@
 
             Best regards
         </field>
+        <field name="mail_show_invoice_detail" eval="True" />
         <field
             name="custom_mail_text"
         ><![CDATA[
@@ -188,6 +192,7 @@
 
             Best regards
         </field>
+        <field name="mail_show_invoice_detail" eval="True" />
         <field
             name="custom_mail_text"
         ><![CDATA[

--- a/account_credit_control/i18n/account_credit_control.pot
+++ b/account_credit_control/i18n/account_credit_control.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-13 07:34+0000\n"
+"PO-Revision-Date: 2023-02-13 07:34+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -194,6 +196,12 @@ msgstr ""
 #. module: account_credit_control
 #: model_terms:ir.actions.act_window,help:account_credit_control.action_wizard_credit_policy_changer
 msgid "Allows to manually change credit level"
+msgstr ""
+
+#. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
+#, python-format
+msgid "Amount Due"
 msgstr ""
 
 #. module: account_credit_control
@@ -596,6 +604,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_policy_level__display_name
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_printer__display_name
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_run__display_name
+#: model:ir.model.fields,field_description:account_credit_control.field_mail_compose_message__display_name
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_mail__display_name
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_message__display_name
 #: model:ir.model.fields,field_description:account_credit_control.field_res_company__display_name
@@ -665,7 +674,9 @@ msgid "Due balance"
 msgstr ""
 
 #. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_line__date_due
+#, python-format
 msgid "Due date"
 msgstr ""
 
@@ -678,6 +689,11 @@ msgstr ""
 #. module: account_credit_control
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_policy_level__email_template_id
 msgid "Email Template"
+msgstr ""
+
+#. module: account_credit_control
+#: model:ir.model,name:account_credit_control.model_mail_compose_message
+msgid "Email composition wizard"
 msgstr ""
 
 #. module: account_credit_control
@@ -778,6 +794,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_policy_level__id
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_printer__id
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_run__id
+#: model:ir.model.fields,field_description:account_credit_control.field_mail_compose_message__id
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_mail__id
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_message__id
 #: model:ir.model.fields,field_description:account_credit_control.field_res_company__id
@@ -841,18 +858,34 @@ msgid "Invoice"
 msgstr ""
 
 #. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
+#, python-format
+msgid "Invoice amount"
+msgstr ""
+
+#. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
 #: model_terms:ir.ui.view,arch_db:account_credit_control.report_credit_control_summary_document
+#, python-format
 msgid "Invoice date"
 msgstr ""
 
 #. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
 #: model_terms:ir.ui.view,arch_db:account_credit_control.report_credit_control_summary_document
+#, python-format
 msgid "Invoice number"
 msgstr ""
 
 #. module: account_credit_control
 #: model_terms:ir.ui.view,arch_db:account_credit_control.report_credit_control_summary_document
 msgid "Invoiced amount"
+msgstr ""
+
+#. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
+#, python-format
+msgid "Invoices summary"
 msgstr ""
 
 #. module: account_credit_control
@@ -884,6 +917,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_policy_level____last_update
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_printer____last_update
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_run____last_update
+#: model:ir.model.fields,field_description:account_credit_control.field_mail_compose_message____last_update
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_mail____last_update
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_message____last_update
 #: model:ir.model.fields,field_description:account_credit_control.field_res_company____last_update
@@ -1589,6 +1623,11 @@ msgstr ""
 #. module: account_credit_control
 #: model_terms:ir.ui.view,arch_db:account_credit_control.credit_control_run_form
 msgid "Set to ready all"
+msgstr ""
+
+#. module: account_credit_control
+#: model:ir.model.fields,field_description:account_credit_control.field_credit_control_policy_level__mail_show_invoice_detail
+msgid "Show Invoice Details in mail"
 msgstr ""
 
 #. module: account_credit_control

--- a/account_credit_control/i18n/es.po
+++ b/account_credit_control/i18n/es.po
@@ -8,16 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-26 12:28+0000\n"
-"PO-Revision-Date: 2022-09-21 16:22+0000\n"
+"POT-Creation-Date: 2023-02-13 07:34+0000\n"
+"PO-Revision-Date: 2023-02-13 08:35+0100\n"
 "Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: account_credit_control
 #: model:credit.control.policy.level,custom_text:account_credit_control.3_time_3
@@ -237,6 +237,12 @@ msgid "Allows to manually change credit level"
 msgstr "Permite cambiar manualmente el nivel de crédito"
 
 #. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
+#, python-format
+msgid "Amount Due"
+msgstr "Importe pendiente"
+
+#. module: account_credit_control
 #: model_terms:ir.ui.view,arch_db:account_credit_control.credit_control_line_search
 msgid "An error has occured during the sending of the email."
 msgstr "Ha ocurrido un error durante el envío del correo electrónico."
@@ -361,9 +367,8 @@ msgstr "Modo de cálculo"
 
 #. module: account_credit_control
 #: model:ir.model,name:account_credit_control.model_res_config_settings
-#, fuzzy
 msgid "Config Settings"
-msgstr "res.config.settings"
+msgstr ""
 
 #. module: account_credit_control
 #: model:ir.model,name:account_credit_control.model_res_partner
@@ -642,6 +647,7 @@ msgstr "Configuración de retardo"
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_policy_level__display_name
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_printer__display_name
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_run__display_name
+#: model:ir.model.fields,field_description:account_credit_control.field_mail_compose_message__display_name
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_mail__display_name
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_message__display_name
 #: model:ir.model.fields,field_description:account_credit_control.field_res_company__display_name
@@ -715,7 +721,9 @@ msgid "Due balance"
 msgstr "Saldo vencido"
 
 #. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_line__date_due
+#, python-format
 msgid "Due date"
 msgstr "Fecha de vencimiento"
 
@@ -729,6 +737,11 @@ msgstr "Correo electrónico"
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_policy_level__email_template_id
 msgid "Email Template"
 msgstr "Plantilla de correo"
+
+#. module: account_credit_control
+#: model:ir.model,name:account_credit_control.model_mail_compose_message
+msgid "Email composition wizard"
+msgstr ""
 
 #. module: account_credit_control
 #: model:ir.model.fields.selection,name:account_credit_control.selection__credit_control_line__state__email_error
@@ -830,6 +843,7 @@ msgstr "Esconder botón Cambiar Estado"
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_policy_level__id
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_printer__id
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_run__id
+#: model:ir.model.fields,field_description:account_credit_control.field_mail_compose_message__id
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_mail__id
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_message__id
 #: model:ir.model.fields,field_description:account_credit_control.field_res_company__id
@@ -895,12 +909,22 @@ msgid "Invoice"
 msgstr "Factura"
 
 #. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
+#, python-format
+msgid "Invoice amount"
+msgstr "Importe factura"
+
+#. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
 #: model_terms:ir.ui.view,arch_db:account_credit_control.report_credit_control_summary_document
+#, python-format
 msgid "Invoice date"
 msgstr "Fecha de factura"
 
 #. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
 #: model_terms:ir.ui.view,arch_db:account_credit_control.report_credit_control_summary_document
+#, python-format
 msgid "Invoice number"
 msgstr "Nº de factura"
 
@@ -908,6 +932,12 @@ msgstr "Nº de factura"
 #: model_terms:ir.ui.view,arch_db:account_credit_control.report_credit_control_summary_document
 msgid "Invoiced amount"
 msgstr "Importe facturado"
+
+#. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
+#, python-format
+msgid "Invoices summary"
+msgstr "Resumen de facturas"
 
 #. module: account_credit_control
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_communication__message_is_follower
@@ -938,6 +968,7 @@ msgstr "Entrada de jornada"
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_policy_level____last_update
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_printer____last_update
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_run____last_update
+#: model:ir.model.fields,field_description:account_credit_control.field_mail_compose_message____last_update
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_mail____last_update
 #: model:ir.model.fields,field_description:account_credit_control.field_mail_message____last_update
 #: model:ir.model.fields,field_description:account_credit_control.field_res_company____last_update
@@ -1101,7 +1132,6 @@ msgstr "Marcar como"
 
 #. module: account_credit_control
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_printer__mark_as_sent
-#, fuzzy
 msgid "Mark letter lines as done"
 msgstr "Marcar líneas de carta como enviadas"
 
@@ -1408,8 +1438,8 @@ msgstr ""
 "aviso.<br>\n"
 "  si ya lo ha enviado, por favor ignore este aviso. si no, por favor proceda "
 "con el pagamiento en un término de 5 dias.<br>\n"
-"  gracias por adelantado por su participacion anticipada en este asunto.<br>"
-"\n"
+"  gracias por adelantado por su participacion anticipada en este asunto."
+"<br>\n"
 "  <br>\n"
 "  Saludos coordiales"
 
@@ -1722,6 +1752,11 @@ msgid "Set to ready all"
 msgstr ""
 
 #. module: account_credit_control
+#: model:ir.model.fields,field_description:account_credit_control.field_credit_control_policy_level__mail_show_invoice_detail
+msgid "Show Invoice Details in mail"
+msgstr "Mostrar detalles de la factura en el correo electrónico"
+
+#. module: account_credit_control
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_line__run_id
 msgid "Source"
 msgstr "Origen"
@@ -1810,11 +1845,8 @@ msgstr "El menor nivel no puede ser de tipo Recordatorio previo"
 
 #. module: account_credit_control
 #: model_terms:ir.ui.view,arch_db:account_credit_control.credit_control_line_search
-#, fuzzy
 msgid "These lines are to do using the Actions."
 msgstr ""
-"Estas líneas están disponibles para ser enviadas por correo electrónico o "
-"por carta usando las acciones."
 
 #. module: account_credit_control
 #: model_terms:ir.ui.view,arch_db:account_credit_control.res_config_settings_view_form
@@ -1892,7 +1924,7 @@ msgstr "Usuario"
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_communication__website_message_ids
 #: model:ir.model.fields,field_description:account_credit_control.field_credit_control_line__website_message_ids
 msgid "Website Messages"
-msgstr ""
+msgstr "Mensajes del sitio wew"
 
 #. module: account_credit_control
 #: model:ir.model.fields,help:account_credit_control.field_credit_control_communication__website_message_ids
@@ -1938,75 +1970,3 @@ msgstr ""
 #: model:ir.model,name:account_credit_control.model_credit_control_communication
 msgid "credit control communication"
 msgstr "comunicación de control de crédito"
-
-#~ msgid "Credit control policy Level"
-#~ msgstr "Nivel de política de control de crédito"
-
-#~ msgid "Credit control policy level"
-#~ msgstr "Nivel de política de control de crédito"
-
-#~ msgid "Customer Followup"
-#~ msgstr "Seguimiento del cliente"
-
-#~ msgid "Default Credit Tolerance"
-#~ msgstr "Tolerancia de crédito por defecto"
-
-#~ msgid "Default Policy"
-#~ msgstr "Política por defecto"
-
-#~ msgid ""
-#~ "\n"
-#~ "  Dear ${object.contact_address.name or ''}\n"
-#~ "  <br/>\n"
-#~ "  <br/>\n"
-#~ "  ${object.current_policy_level.custom_mail_text | safe}\n"
-#~ "  "
-#~ msgstr ""
-#~ "\n"
-#~ "  Estimado/a ${object.contact_address.name or ''}\n"
-#~ "  <br/>\n"
-#~ "  <br/>\n"
-#~ "  ${object.current_policy_level.custom_mail_text | safe}\n"
-#~ "  "
-
-#, fuzzy
-#~ msgid "Control Lines"
-#~ msgstr "Líneas de control de crédito"
-
-#~ msgid ""
-#~ "Credit Control:\n"
-#~ "            (${object.current_policy_level.name or 'n/a'})\n"
-#~ "        "
-#~ msgstr ""
-#~ "Control de crédito:\n"
-#~ "            (${object.current_policy_level.name or 'n/a'})\n"
-#~ "        "
-
-#~ msgid "Sent Email"
-#~ msgstr "Correo electrónico enviado"
-
-#, fuzzy
-#~| msgid "Overdue Level"
-#~ msgid "Overdue"
-#~ msgstr "Nivel de retraso"
-
-#~ msgid "The optional other currency if it is a multi-currency entry."
-#~ msgstr "La otra moneda opcional si es un asiento multi-moneda."
-
-#~ msgid "Ready To Send"
-#~ msgstr "Listo para ser enviado"
-
-#~ msgid "Sent"
-#~ msgstr "Enviado"
-
-#~ msgid "Sent date"
-#~ msgstr "Fecha de envío"
-
-#~ msgid "Follow-up"
-#~ msgstr "Seguimiento"
-
-#~ msgid "credit.control.policy.changer"
-#~ msgstr "credit.control.policy.changer"
-
-#~ msgid "Open Credit Control Lines"
-#~ msgstr "Abrir líneas de control de crédito"

--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -249,6 +249,7 @@ class CreditControlPolicyLevel(models.Model):
     email_template_id = fields.Many2one(comodel_name="mail.template", required=True)
     channel = fields.Selection(selection=CHANNEL_LIST, required=True)
     custom_text = fields.Text(string="Custom Message", required=True, translate=True)
+    mail_show_invoice_detail = fields.Boolean(string="Show Invoice Details in mail")
     custom_mail_text = fields.Html(
         string="Custom Mail Message", required=True, translate=True
     )

--- a/account_credit_control/readme/CONTRIBUTORS.rst
+++ b/account_credit_control/readme/CONTRIBUTORS.rst
@@ -13,6 +13,7 @@
   * Pedro M. Baeza
   * Jairo Llopis
   * João Marques
+  * Víctor Martínez
 
 * Enric Tobella <etobella@creublanca.es>
 * Naglis Jonaitis (Versada UAB) <naglis@versada.eu>

--- a/account_credit_control/static/description/index.html
+++ b/account_credit_control/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Account Credit Control</title>
 <style type="text/css">
 
@@ -457,6 +457,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Pedro M. Baeza</li>
 <li>Jairo Llopis</li>
 <li>João Marques</li>
+<li>Víctor Martínez</li>
 </ul>
 </li>
 <li>Enric Tobella &lt;<a class="reference external" href="mailto:etobella&#64;creublanca.es">etobella&#64;creublanca.es</a>&gt;</li>

--- a/account_credit_control/views/credit_control_policy.xml
+++ b/account_credit_control/views/credit_control_policy.xml
@@ -53,6 +53,10 @@
                                             />
                                             <newline />
                                             <field
+                                                name="mail_show_invoice_detail"
+                                                attrs="{'invisible': [('channel', '!=', 'email')]}"
+                                            />
+                                            <field
                                                 name="custom_mail_text"
                                                 colspan="4"
                                             />

--- a/account_credit_control/wizard/__init__.py
+++ b/account_credit_control/wizard/__init__.py
@@ -3,3 +3,4 @@ from . import credit_control_emailer
 from . import credit_control_marker
 from . import credit_control_printer
 from . import credit_control_policy_changer
+from . import mail_compose_message

--- a/account_credit_control/wizard/mail_compose_message.py
+++ b/account_credit_control/wizard/mail_compose_message.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class MailComposer(models.TransientModel):
+    _inherit = "mail.compose.message"
+
+    def onchange_template_id(self, template_id, composition_mode, model, res_id):
+        res = super().onchange_template_id(
+            template_id=template_id,
+            composition_mode=composition_mode,
+            model=model,
+            res_id=res_id,
+        )
+        if self.env.context.get("inject_credit_control_communication_table"):
+            record = self.env[model].browse(res_id)
+            res["value"]["body"] += record._get_credit_control_communication_table()
+        return res


### PR DESCRIPTION
Add details (table) to communication mail template.
![ejemplo](https://user-images.githubusercontent.com/4117568/214878008-c1757867-5f5f-43da-8ff7-a5d2e64fcfa7.png)

Please @pedrobaeza and @ernestotejeda can you review it?

@Tecnativa TT41337