### PR TITLE
[15.0][FIX] Restored Credit Contro Lines menu actions

### DIFF
--- a/account_credit_control/wizard/credit_control_emailer_view.xml
+++ b/account_credit_control/wizard/credit_control_emailer_view.xml
@@ -35,7 +35,7 @@
         <field name="name">Send By Email</field>
         <field name="res_model">credit.control.emailer</field>
         <field name="binding_model_id" ref="model_credit_control_line" />
-        <field name="binding_view_types">form</field>
+        <field name="binding_view_types">form,list</field>
         <field name="target">new</field>
         <field name="view_mode">form</field>
     </record>

--- a/account_credit_control/wizard/credit_control_marker_view.xml
+++ b/account_credit_control/wizard/credit_control_marker_view.xml
@@ -44,7 +44,7 @@
         <field name="name">Change Lines' State</field>
         <field name="res_model">credit.control.marker</field>
         <field name="binding_model_id" ref="model_credit_control_line" />
-        <field name="binding_view_types">form</field>
+        <field name="binding_view_types">form,list</field>
         <field name="target">new</field>
         <field name="view_mode">form</field>
     </record>

--- a/account_credit_control/wizard/credit_control_printer_view.xml
+++ b/account_credit_control/wizard/credit_control_printer_view.xml
@@ -31,16 +31,16 @@
     <!-- for menu -->
 
 
-            <record
+    <record
         id="open_credit_line_printer_wizard_menu_action"
         model="ir.actions.act_window"
     >
         <field name="name">Print Lines</field>
         <field name="res_model">credit.control.printer</field>
         <field name="binding_model_id" ref="model_credit_control_line" />
-        <field name="binding_view_types">form</field>
-            <field name="target">new</field>
-                <field name="view_mode">form</field>
+        <field name="binding_view_types">form,list</field>
+        <field name="target">new</field>
+        <field name="view_mode">form</field>
     </record>
 
     <record id="open_credit_line_printer_wizard" model="ir.actions.act_window">


### PR DESCRIPTION
Until v14, actions "**Print Lines**", "**Change Lines' Style**" and "**Send by Email**" were selectable from list view of `credit.control.line` : (Screenshot from v14)

![Screenshot from 2023-02-08 15-56-40](https://user-images.githubusercontent.com/8192093/217568891-4204fc67-4f26-4a63-8926-b45f72dccafc.png)

On v15 those actions still exist, but they're not bound to the list view : (Screenshot from v15)

![Screenshot from 2023-02-08 15-56-23](https://user-images.githubusercontent.com/8192093/217569001-ddf67b40-7e40-4db4-a94e-841c473a986b.png)

This PR proposes to fix it : (Screenshot from v15 after changes in this PR are applied)

![Screenshot from 2023-02-08 16-03-02](https://user-images.githubusercontent.com/8192093/217569140-65515793-5702-429a-afe3-2c0c587f2297.png)

