### PR TITLE
[12.0][FIX] account_invoice_overdue_reminder: Avoid ensure_one errors

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -618,9 +618,11 @@ class OverdueRemindMassUpdate(models.TransientModel):
         actions = self.env['overdue.reminder.step'].browse(
             self._context.get('active_ids'))
         if self.update_action == 'validate':
-            actions.validate()
+            for action in actions:
+                action.validate()
         elif self.update_action == 'skip':
-            actions.skip()
+            for action in actions:
+                action.skip()
         elif self.update_action == 'reminder_type':
             if not self.reminder_type:
                 raise UserError(_("You must select the new reminder type."))


### PR DESCRIPTION
This fix avoids the "ensure_one" error got trying to validate several reminders in bulk from "Overdue Invoice Step" tree view