### PR TITLE
[FIX] Credit Control View open issue

### DIFF
--- a/account_credit_control/wizard/credit_control_policy_changer_view.xml
+++ b/account_credit_control/wizard/credit_control_policy_changer_view.xml
@@ -63,6 +63,7 @@
         <field name="res_model">credit.control.policy.changer</field>
         <field name="binding_model_id" ref="account.model_account_move" />
         <field name="binding_view_types">form</field>
+        <field name="view_id" ref="credit_control_policy_changer_form" />
             <field name="target">new</field>
     </record>
 


### PR DESCRIPTION

-  "change current credit policy" menu action has no view reference.
-  this action points to the blank view of change current credit policy.
- so added view id in menu action of change current credit policy.

