### PR TITLE
[15.0][FIX] partner_risk_insurance: warning message for invalid field parameter tracking

### DIFF
--- a/partner_risk_insurance/__manifest__.py
+++ b/partner_risk_insurance/__manifest__.py
@@ -12,7 +12,7 @@
     "license": "AGPL-3",
     "application": False,
     "website": "https://github.com/OCA/credit-control",
-    "depends": ["base"],
+    "depends": ["mail"],  # required for tracking=True attribute
     "category": "Credit Control",
     "data": ["security/ir.model.access.csv", "views/res_partner_view.xml"],
     "installable": True,


### PR DESCRIPTION
cc @Tecnativa

This module has not dependency from mail, so the tracking parameter is invalid.

ping @carlosdauden @chienandalu 