### PR TITLE
[16.0] account_invoice_overdue_reminder: allow to remove invoices in the wizard

### DIFF
--- a/account_invoice_overdue_reminder/security/ir.model.access.csv
+++ b/account_invoice_overdue_reminder/security/ir.model.access.csv
@@ -8,5 +8,4 @@ access_account_invoice_overdue_reminder_manager,Full access on reminder counters
 access_overdue_reminder_start,Full access on overdue.reminder.start (wizard),model_overdue_reminder_start,account.group_account_invoice,1,1,1,1
 access_overdue_reminder_start_payment,Full access on overdue.reminder.start.payment (wizard),model_overdue_reminder_start_payment,account.group_account_invoice,1,1,1,1
 access_overdue_reminder_step,Full access on overdue.reminder.step (wizard),model_overdue_reminder_step,account.group_account_invoice,1,1,1,1
-access_overdue_reminder_end,Full access on overdue.reminder.end (wizard),model_overdue_reminder_end,account.group_account_invoice,1,1,1,1
 access_overdue_reminder_mass_update,Full access on overdue.reminder.mass.update (wizard),model_overdue_reminder_mass_update,account.group_account_invoice,1,1,1,1

--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard_view.xml
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard_view.xml
@@ -36,10 +36,6 @@
                         <field name="last_entry_create_uid" />
                     </tree>
                 </field>
-                <div name="up_to_date" colspan="2">
-                    <field name="up_to_date" class="oe_inline" />
-                    <label for="up_to_date" />
-                </div>
             </group>
             <footer>
                 <button name="run" type="object" string="Start" class="btn-primary" />
@@ -117,6 +113,8 @@
                 <field name="partner_phone" widget="phone" />
                 <field name="partner_email" widget="email" />
                 <field name="partner_mobile" widget="phone" />
+                <field name="date" invisible="1" />
+                <field name="company_id" invisible="1" />
             </group>
             <group
                     attrs="{'invisible': [('warn_unreconciled_move_line_ids', '=', [])]}"
@@ -291,29 +289,6 @@
     <field name="res_model">overdue.reminder.step</field>
     <field name="view_mode">tree,form</field>
     <field name="domain">[('state', '=', 'draft'), ('user_id', '=', uid)]</field>
-</record>
-
-<record id="overdue_reminder_end_form" model="ir.ui.view">
-    <field name="name">overdue.reminder.end.form</field>
-    <field name="model">overdue.reminder.end</field>
-    <field name="arch" type="xml">
-        <form>
-            <div>
-                <h2>Good job !</h2>
-                <p>You processed all your overdue invoice reminders.</p>
-            </div>
-            <footer>
-                <button special="cancel" string="Close" class="btn-primary" />
-            </footer>
-        </form>
-    </field>
-</record>
-
-<record id="overdue_reminder_end_action" model="ir.actions.act_window">
-    <field name="name">Overdue Invoice End</field>
-    <field name="res_model">overdue.reminder.end</field>
-    <field name="view_mode">form</field>
-    <field name="target">new</field>
 </record>
 
 <record id="overdue_reminder_mass_update_form" model="ir.ui.view">

--- a/account_invoice_overdue_reminder/wizard/res_config_settings_view.xml
+++ b/account_invoice_overdue_reminder/wizard/res_config_settings_view.xml
@@ -36,7 +36,7 @@
                 </div>
                 <div
                         class="col-12 col-md-12 o_setting_box"
-                        id="overdue_reminder_attach_invoice"
+                        id="overdue_reminder_other_fields"
                     >
                         <div class="o_setting_left_pane" />
                     <div class="o_setting_right_pane">


### PR DESCRIPTION
Allow to remove invoices in the wizard : same feature as https://github.com/OCA/credit-control/pull/170 but the a different implementation that doesn't need a button to refresh the wizard
Remove the end step in the wizard (replaced by a notification)
Remove the up_to_date boolean on the start wizard
Code cleanup