### PR TITLE
[16.0][FIX] account_credit_control: avoid AccessError in open_credit_lines()

### DIFF
--- a/account_credit_control/models/credit_control_run.py
+++ b/account_credit_control/models/credit_control_run.py
@@ -182,10 +182,8 @@ class CreditControlRun(models.Model):
     def open_credit_communications(self):
         """Open the generated communications."""
         self.ensure_one()
-        action = self.env.ref(
-            "account_credit_control.credit_control_communication_action"
-        )
-        action = action.read()[0]
+        action_name = "account_credit_control.credit_control_communication_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_name)
         action["domain"] = [
             ("id", "in", self.mapped("line_ids.communication_id").ids),
         ]
@@ -195,8 +193,7 @@ class CreditControlRun(models.Model):
         """Open the generated lines"""
         self.ensure_one()
         action_name = "account_credit_control.credit_control_line_action"
-        action = self.env.ref(action_name)
-        action = action.read()[0]
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_name)
         action["domain"] = [("id", "in", self.line_ids.ids)]
         return action
 

--- a/account_credit_control/tests/test_credit_control_run.py
+++ b/account_credit_control/tests/test_credit_control_run.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from dateutil import relativedelta
 
 from odoo import fields
-from odoo.exceptions import UserError
+from odoo.exceptions import AccessError, UserError
 from odoo.tests import tagged
 from odoo.tests.common import Form
 
@@ -221,3 +221,57 @@ class TestCreditControlRun(AccountTestInvoicingCommon):
             active_model="credit.control.line", active_ids=control_lines.ids
         ).create({})
         wiz_printer.print_lines()
+
+    def test_open_credit_lines(self):
+        """
+        Test access rights when invoking method open_credit_lines
+        """
+        # Create credit lines
+        control_run = self.env["credit.control.run"].create(
+            {"date": fields.Date.today(), "policy_ids": [(6, 0, [self.policy.id])]}
+        )
+        control_run.with_context(lang="en_US").generate_credit_lines()
+        self.assertEqual(len(self.invoice.credit_control_line_ids), 1)
+        self.assertEqual(control_run.state, "done")
+
+        # Set company_ids for user demo
+        user_demo = self.env.ref("base.user_demo")
+        user_demo.company_ids += control_run.company_id
+
+        # User demo tries to read credit_control_line_action directly
+        action_name = "account_credit_control.credit_control_line_action"
+        action = self.env.ref(action_name)
+        with self.assertRaises(AccessError):
+            # AccessError raised
+            action.with_user(user_demo.id).read()[0]
+
+        # Invoking open_credit_lines: AccessError not raised
+        action = control_run.with_user(user_demo.id).open_credit_lines()
+        self.assertIn("domain", action)
+
+    def test_open_credit_communications(self):
+        """
+        Test access rights when invoking method open_credit_communications
+        """
+        # Create credit lines
+        control_run = self.env["credit.control.run"].create(
+            {"date": fields.Date.today(), "policy_ids": [(6, 0, [self.policy.id])]}
+        )
+        control_run.with_context(lang="en_US").generate_credit_lines()
+        self.assertEqual(len(self.invoice.credit_control_line_ids), 1)
+        self.assertEqual(control_run.state, "done")
+
+        # Set company_ids for user demo
+        user_demo = self.env.ref("base.user_demo")
+        user_demo.company_ids += control_run.company_id
+
+        # User demo tries to read credit_control_communication_action directly
+        action_name = "account_credit_control.credit_control_communication_action"
+        action = self.env.ref(action_name)
+        with self.assertRaises(AccessError):
+            # AccessError raised
+            action.with_user(user_demo.id).read()[0]
+
+        # Invoking open_credit_communications: AccessError not raised
+        action = control_run.with_user(user_demo.id).open_credit_communications()
+        self.assertIn("domain", action)


### PR DESCRIPTION
This fixes the error described by @grindtildeath in https://github.com/OCA/credit-control/pull/268#discussion_r1214529162