### PR TITLE
[15.0][IMP] sale_financial_risk: credit_limit change performance

### DIFF
--- a/sale_financial_risk/models/sale.py
+++ b/sale_financial_risk/models/sale.py
@@ -8,6 +8,11 @@ from odoo.tools import float_round
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    # Index this field is affected by the related field risk_partner_id. Mainly when
+    # commercial fields in the partner are written and thus recomputation of that
+    # relation is triggered.
+    partner_invoice_id = fields.Many2one(index=True)
+
     def evaluate_risk_message(self, partner):
         self.ensure_one()
         risk_amount = self.currency_id._convert(


### PR DESCRIPTION
res.partner credit_limit field is a commercial field that triggers the children syncronization. In partners with lots of children, those recalculations can lead to a poor user experience when a operation that is replicated over all the children doesn't perform fine. This is the case with the risk_partner_id field, wich relation is recalculated a thus as many queries as children has the contact (it can be dozens).

In the issue case we passed from a write time of ~40 seconds to ~3 seconds for this type of contacts.

An example of the performance difference achieved by the index:

![image](https://github.com/OCA/credit-control/assets/5040182/6e8d60ce-bd31-43f5-b3ab-17e5ef09bef2)

Graphical example of the issue:

Before (in the bottom of the graphic you can see that it takes about ~40 seconds which are took by the poor performance of all the queries like: `SELECT "sale_order".id FROM "sale_order" WHERE ("sale_order"."partner_invoice_id" in (%s)) ORDER BY  "sale_order"."id" `:

![image](https://github.com/OCA/credit-control/assets/5040182/813d4038-d289-41de-9372-25e588c4437b)

After (notice that the overalltime is now ~3):

![image](https://github.com/OCA/credit-control/assets/5040182/c4fa603e-88d9-4a18-8279-c5a75ae456f5)


cc @Tecnativa TT43572

please review @carlosdauden @pedrobaeza 