### PR TITLE
[15.0][IMP] account_credit_control: Add Payment Reference from invoice to communication table

### DIFF
--- a/account_credit_control/i18n/account_credit_control.pot
+++ b/account_credit_control/i18n/account_credit_control.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-06-22 07:46+0000\n"
+"PO-Revision-Date: 2023-06-22 07:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1398,6 +1400,12 @@ msgstr ""
 #: model:ir.model.fields,help:account_credit_control.field_res_partner__payment_note
 #: model:ir.model.fields,help:account_credit_control.field_res_users__payment_note
 msgid "Payment Note"
+msgstr ""
+
+#. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
+#, python-format
+msgid "Payment Reference"
 msgstr ""
 
 #. module: account_credit_control

--- a/account_credit_control/i18n/es.po
+++ b/account_credit_control/i18n/es.po
@@ -1484,6 +1484,12 @@ msgid "Payment Note"
 msgstr "Nota del pago"
 
 #. module: account_credit_control
+#: code:addons/account_credit_control/models/credit_control_communication.py:0
+#, python-format
+msgid "Payment Reference"
+msgstr "Referencia de pago"
+
+#. module: account_credit_control
 #: model:ir.model.fields.selection,name:account_credit_control.selection__credit_control_line__channel__phone
 #: model:ir.model.fields.selection,name:account_credit_control.selection__credit_control_policy_level__channel__phone
 msgid "Phone"

--- a/account_credit_control/models/credit_control_communication.py
+++ b/account_credit_control/models/credit_control_communication.py
@@ -178,6 +178,7 @@ class CreditControlCommunication(models.Model):
     def _get_credit_control_communication_table(self):
         th_style = "padding: 5px; border: 1px solid black;"
         tr_content = "<th style='%s'>%s</th>" % (th_style, _("Invoice number"))
+        tr_content += "<th style='%s'>%s</th>" % (th_style, _("Payment Reference"))
         tr_content += "<th style='%s'>%s</th>" % (th_style, _("Invoice date"))
         tr_content += "<th style='%s'>%s</th>" % (th_style, _("Due date"))
         tr_content += "<th style='%s'>%s</th>" % (th_style, _("Invoice amount"))
@@ -188,6 +189,10 @@ class CreditControlCommunication(models.Model):
         table_content += "<table style='%s'><tr>%s</tr>" % (table_style, tr_content)
         for line in self.credit_control_line_ids:
             tr_content = "<td style='%s'>%s</td>" % (th_style, line.invoice_id.name)
+            tr_content += "<td style='%s'>%s</td>" % (
+                th_style,
+                line.invoice_id.payment_reference or "",
+            )
             tr_content += "<td style='%s'>%s</td>" % (
                 th_style,
                 format_date(self.env, line.invoice_id.invoice_date),

--- a/account_credit_control/wizard/mail_compose_message.py
+++ b/account_credit_control/wizard/mail_compose_message.py
@@ -1,14 +1,16 @@
 # Copyright 2023 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from markupsafe import Markup
+
 from odoo import models
 
 
 class MailComposer(models.TransientModel):
     _inherit = "mail.compose.message"
 
-    def onchange_template_id(self, template_id, composition_mode, model, res_id):
-        res = super().onchange_template_id(
+    def _onchange_template_id(self, template_id, composition_mode, model, res_id):
+        res = super()._onchange_template_id(
             template_id=template_id,
             composition_mode=composition_mode,
             model=model,
@@ -16,5 +18,7 @@ class MailComposer(models.TransientModel):
         )
         if self.env.context.get("inject_credit_control_communication_table"):
             record = self.env[model].browse(res_id)
-            res["value"]["body"] += record._get_credit_control_communication_table()
+            res["value"]["body"] += Markup(
+                record._get_credit_control_communication_table()
+            )
         return res


### PR DESCRIPTION
Changes done:
- [x] **IMP**: Add Payment Reference from invoice to communication table (FWP from 14.0: https://github.com/OCA/credit-control/pull/289)
- [x] **FIX**: Add table to email content

@Tecnativa TT41337