### PR TITLE
[IMP] Minor fix to Financial Risk tab layout

### DIFF
--- a/account_financial_risk/views/res_partner_view.xml
+++ b/account_financial_risk/views/res_partner_view.xml
@@ -183,23 +183,15 @@
                         </group>
                     </group>
                     <group string="Info" col="4">
-                        <label for="credit_currency" />
-                        <div class="o_row">
-                            <field
-                                name="credit_currency"
-                                attrs="{'readonly': [('risk_allow_edit', '=', False)]}"
-                                nolabel="1"
-                            />
-                            <span>
-                                (
-                                <field
-                                    name="risk_currency_id"
-                                    readonly="1"
-                                    nolabel="1"
-                                />
-                                )
-                            </span>
-                        </div>
+                        <field
+                            name="credit_currency"
+                            attrs="{'readonly': [('risk_allow_edit', '=', False)]}"
+                        />
+                        <field
+                            name="risk_currency_id"
+                            readonly="1"
+                            attrs="{'invisible': [('credit_currency', '=', 'manual')]}"
+                        />
                         <field
                             name="manual_credit_currency_id"
                             options="{'no_create': True}"


### PR DESCRIPTION
Old Layout:
![image](https://github.com/OCA/credit-control/assets/1309054/a6679da7-a269-4151-b6d4-311f35234f1e)

New Layout
![image](https://github.com/OCA/credit-control/assets/1309054/459d8771-1d3a-4cc8-abd2-ca0fe303ceda)
