### PR TITLE
[15.0][FIX] account_financial_risk: Make tests resilient

### DIFF
--- a/account_financial_risk/tests/test_account_financial_risk.py
+++ b/account_financial_risk/tests/test_account_financial_risk.py
@@ -16,10 +16,14 @@ class TestPartnerFinancialRisk(TransactionCase):
         type_revenue = cls.env.ref("account.data_account_type_revenue")
         type_receivable = cls.env.ref("account.data_account_type_receivable")
         tax_group_taxes = cls.env.ref("account.tax_group_taxes")
-        main_company = cls.env.ref("base.main_company")
-        cls.cr.execute(
+        cls.currency_usd = cls.env.ref("base.USD")
+        cls.currency_usd.active = True
+        # Make sure the currency of the company is USD, as this not always happens
+        # To be removed in V17: https://github.com/odoo/odoo/pull/107113
+        cls.company = cls.env.company
+        cls.env.cr.execute(
             "UPDATE res_company SET currency_id = %s WHERE id = %s",
-            [cls.env.ref("base.USD").id, main_company.id],
+            (cls.currency_usd.id, cls.company.id),
         )
         cls.account_sale = cls.env["account.account"].create(
             {


### PR DESCRIPTION
- Depending on the installed set of modules, the company currency may be USD or EUR. If the second case, these tests will fail, so we make sure that the company currency is USD for our tests, doing the change by SQL, as there's a Python constraint that prevents it.

Not needed in v17 due to: odoo/odoo#107113.

cc @Tecnativa