### PR TITLE
[16.0][FIX] account_credit_control: layout Policy levels / Mail and reporting

### DIFF
--- a/account_credit_control/views/credit_control_policy.xml
+++ b/account_credit_control/views/credit_control_policy.xml
@@ -32,7 +32,7 @@
                             </tree>
                             <form string="Policy level">
                                 <field name="name" />
-                                <notebook colspan="4">
+                                <notebook>
                                     <page string="Delay Setting">
                                         <group>
                                             <field name="level" />
@@ -42,23 +42,24 @@
                                         </group>
                                     </page>
                                     <page string="Mail and reporting">
-                                        <group>
-                                            <field name="email_template_id" />
-                                            <newline />
-                                            <field name="custom_text" colspan="4" />
-                                            <newline />
+                                        <group colspan="2">
+                                            <field
+                                                name="email_template_id"
+                                                colspan="2"
+                                            />
+                                            <field name="custom_text" colspan="2" />
                                             <field
                                                 name="custom_text_after_details"
-                                                colspan="4"
+                                                colspan="2"
                                             />
-                                            <newline />
                                             <field
                                                 name="mail_show_invoice_detail"
                                                 attrs="{'invisible': [('channel', '!=', 'email')]}"
+                                                colspan="2"
                                             />
                                             <field
                                                 name="custom_mail_text"
-                                                colspan="4"
+                                                colspan="2"
                                             />
                                         </group>
                                     </page>


### PR DESCRIPTION
This fixes the layout of the 'Credit Control Policy' notebook-page 'Mail and reporting'.

As shown in the screenshot:
Several related labels and fields not aligned (not on same line) and also the translation buttons are invisible.\

![image](https://github.com/OCA/credit-control/assets/328803/5403e0f6-416a-40b3-8718-006ea267f13d)
