### PR TITLE
[15.0][IMP] account_financial_risk: Remove store parameter from two fields …

### DIFF
--- a/account_financial_risk/models/res_partner.py
+++ b/account_financial_risk/models/res_partner.py
@@ -162,13 +162,11 @@ class ResPartner(models.Model):
         compute="_compute_risk_remaining",
         string="Risk Remaining (Value)",
         currency_field="risk_currency_id",
-        store=True,
     )
 
     risk_remaining_percentage = fields.Float(
         compute="_compute_risk_remaining",
         string="Risk Remaining (Percentage)",
-        store=True,
     )
 
     @api.depends("credit_limit")


### PR DESCRIPTION
…that depend on a non-stored field.

https://github.com/OCA/credit-control/blob/4d57ace556ff9b479a8346c13ca85a4ce7f34d31/account_financial_risk/models/res_partner.py#L179-L185

https://github.com/OCA/credit-control/blob/4d57ace556ff9b479a8346c13ca85a4ce7f34d31/account_financial_risk/models/res_partner.py#L119-L124

@Tecnativa