### PR TITLE
[15.0][FIX] sale_financial_risk: fix test

### DIFF
--- a/sale_financial_risk/tests/test_partner_sale_risk.py
+++ b/sale_financial_risk/tests/test_partner_sale_risk.py
@@ -32,9 +32,7 @@ class TestPartnerSaleRisk(TransactionCase):
         )
         cls.main_currency = cls.env.company.currency_id
         cls.EUR = cls.env.ref("base.EUR")
-        cls.other_company = cls.env["res.company"].create(
-            {"name": "Company 2", "currency_id": cls.EUR.id}
-        )
+        cls.USD = cls.env.ref("base.USD")
         cls.sale_order = cls.create_sale_order(cls.main_currency, cls.env.company)
         cls.env.user.lang = "en_US"
 
@@ -193,7 +191,12 @@ class TestPartnerSaleRisk(TransactionCase):
         self.assertTrue(action["domain"])
 
     def test_manual_currency_risk_not_exceeded(self):
-        self.product_pricelist.currency_id = self.EUR
+        if self.env.company.currency_id == self.EUR:
+            self.product_pricelist.currency_id = self.USD
+            currency = self.USD
+        else:
+            self.product_pricelist.currency_id = self.EUR
+            currency = self.EUR
         self.partner.write(
             {
                 "risk_sale_order_limit": 99,
@@ -208,19 +211,22 @@ class TestPartnerSaleRisk(TransactionCase):
                 "currency_id": self.main_currency.id,
                 "name": fields.Date.today(),
                 "rate": 0.5,
-                "company_id": self.other_company.id,
+                "company_id": self.env.company.id,
             }
         )
-        sale_order = self.create_sale_order(
-            currency=self.EUR, company=self.other_company
-        )
+        sale_order = self.create_sale_order(currency=currency, company=self.env.company)
         result = sale_order.action_confirm()
 
         # Limit not exceeded
         self.assertEqual(result, True)
 
     def test_manual_currency_risk_exceeded(self):
-        self.product_pricelist.currency_id = self.EUR
+        if self.env.company.currency_id == self.EUR:
+            self.product_pricelist.currency_id = self.USD
+            currency = self.USD
+        else:
+            self.product_pricelist.currency_id = self.EUR
+            currency = self.EUR
         self.partner.write(
             {
                 "risk_sale_order_limit": 99,
@@ -230,18 +236,15 @@ class TestPartnerSaleRisk(TransactionCase):
                 "manual_credit_currency_id": self.main_currency.id,
             }
         )
-        self.product_pricelist.currency_id = self.EUR
         self.env["res.currency.rate"].create(
             {
                 "currency_id": self.main_currency.id,
                 "name": fields.Date.today(),
-                "rate": 1.5,
-                "company_id": self.other_company.id,
+                "rate": 2.0,
+                "company_id": self.env.company.id,
             }
         )
-        sale_order = self.create_sale_order(
-            currency=self.EUR, company=self.other_company
-        )
+        sale_order = self.create_sale_order(currency=currency, company=self.env.company)
         result = sale_order.action_confirm()
 
         # Limit exceeded


### PR DESCRIPTION
The test_manual_currency_risk_not_exceeded test that assesses that the manual currency risk has not been passed fails when another module changes the company's currency. The reason for the failure is that if the company currency matches the currency of the sell order it does not convert correctly and in that case it interprets the limit within the same currency. For example, if the company currency is set as EUR and the sales order is placed in EUR, the conversion of the 100€ is not done and therefore exceeds the limit set to 99. To solve this, the company currency is first checked to set a different currency in the order. On the other hand, the tests should be frozen at a certain date to prevent the exchange rate of the exchange currency from going up or down thus avoiding errors when running the test, which should check that it has not been exceeded.

```
2024-02-22 00:00:00,000 1 ERROR devel odoo.addons.sale_financial_risk.tests.test_partner_sale_risk: FAIL: TestPartnerSaleRisk.test_manual_currency_risk_not_exceeded
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/sale_financial_risk/tests/test_partner_sale_risk.py", line 224, in test_manual_currency_risk_not_exceeded
    self.assertEqual(result, True)
AssertionError: {'type': 'ir.actions.act_window', 'name':[114 chars]new'} != True
```

cc @Tecnativa

@pedrobaeza @carolinafernandez-tecnativa please review
