### PR TITLE
[16.0][FIX] account_credit_control: replace final due amount by balanced amount

### DIFF
--- a/account_credit_control/models/credit_control_communication.py
+++ b/account_credit_control/models/credit_control_communication.py
@@ -203,11 +203,11 @@ class CreditControlCommunication(models.Model):
             )
             tr_content += "<td style='%s'>%s</td>" % (
                 th_style,
-                format_amount(self.env, line.invoice_id.amount_total, line.currency_id),
+                format_amount(self.env, line.amount_due, line.currency_id),
             )
             tr_content += "<td style='%s'>%s</td>" % (
                 th_style,
-                format_amount(self.env, line.amount_due, line.currency_id),
+                format_amount(self.env, line.balance_due, line.currency_id),
             )
             table_content += "<tr>%s</tr>" % tr_content
         table_content += "</table>"


### PR DESCRIPTION
As an invoice can be partially paid, the total due amount should reflect this state.
Changing the communication summary amounts by correct ones.