### PR TITLE
[16.0][IMP] sale_financial_risk_info: groups to risk_info field

### DIFF
--- a/sale_financial_risk_info/views/sale_order_view.xml
+++ b/sale_financial_risk_info/views/sale_order_view.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <record id="view_order_form" model="ir.ui.view">
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='validity_date']" position="before">
-                <field name="risk_info" readonly="1" />
+                <field
+                    name="risk_info"
+                    readonly="1"
+                    groups="account_financial_risk.group_account_financial_risk_user,account_financial_risk.group_account_financial_risk_manager"
+                />
             </xpath>
         </field>
     </record>
-
 </odoo>

--- a/sale_financial_risk_info/views/sale_order_view.xml
+++ b/sale_financial_risk_info/views/sale_order_view.xml
@@ -7,8 +7,7 @@
             <xpath expr="//field[@name='validity_date']" position="before">
                 <field
                     name="risk_info"
-                    readonly="1"
-                    groups="account_financial_risk.group_account_financial_risk_user,account_financial_risk.group_account_financial_risk_manager"
+                    groups="account_financial_risk.group_account_financial_risk_user"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
A user without assigned risk permissions can view the 'Risk Info' field.

![image](https://github.com/OCA/credit-control/assets/170636644/9edec55c-2f0c-4153-9090-6e0511aee960)
![image](https://github.com/OCA/credit-control/assets/170636644/45c0d89a-eb33-402d-abfb-169ea9adbb37)

Without having User or Manager permissions, you should not see that field.

