### PR TITLE
[IMP] account_financial_risk: Send email when risk confirmed

### DIFF
--- a/account_financial_risk/README.rst
+++ b/account_financial_risk/README.rst
@@ -55,6 +55,8 @@ To configure this module, you need to:
 #. In the *Customer Payments* section, fill *Maturity Margin* for setting the
    number of days to last after the due date to consider an invoice as unpaid.
 
+If you want an email to be sent when risk is exceeded in invoices, go to *Invoicing/Accounting > Configuration > Settings > Financial Risk* and fill the field `Email template sent when confirming invoice risk`.
+
 Usage
 =====
 
@@ -104,6 +106,10 @@ Contributors
 * `Ooops404 <https://www.ooops404.com>`__:
 
   * Ilyas <irazor147@gmail.com>
+
+* `Aion Tech <https://aiontech.company/>`_:
+
+  * Simone Rubino <simone.rubino@aion-tech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_financial_risk/models/res_company.py
+++ b/account_financial_risk/models/res_company.py
@@ -1,4 +1,5 @@
 # Copyright 2016-2018 Tecnativa - Carlos Dauden
+# Copyright 2024 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -18,4 +19,10 @@ class ResCompany(models.Model):
         help="Always allow the validation of draft invoices. "
         "Useful when the flow comes from sales orders and the over-risk "
         "has already been allowed when confirming these.",
+    )
+    account_move_confirm_risk_template_id = fields.Many2one(
+        comodel_name="mail.template",
+        string="Email template sent when confirming invoice risk",
+        help="This email template is sent when "
+        "the 'Partner risk exceeded wizard' for an invoice is confirmed.",
     )

--- a/account_financial_risk/models/res_config.py
+++ b/account_financial_risk/models/res_config.py
@@ -1,4 +1,5 @@
 # Copyright 2016-2018 Tecnativa - Carlos Dauden
+# Copyright 2024 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -12,4 +13,8 @@ class AccountConfigSettings(models.TransientModel):
     )
     allow_overrisk_invoice_validation = fields.Boolean(
         related="company_id.allow_overrisk_invoice_validation", readonly=False
+    )
+    account_move_confirm_risk_template_id = fields.Many2one(
+        readonly=False,
+        related="company_id.account_move_confirm_risk_template_id",
     )

--- a/account_financial_risk/models/res_partner.py
+++ b/account_financial_risk/models/res_partner.py
@@ -1,4 +1,5 @@
 # Copyright 2016-2021 Tecnativa - Carlos Dauden
+# Copyright 2024 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from datetime import datetime
@@ -157,6 +158,7 @@ class ResPartner(models.Model):
         store=True,
         readonly=False,
         string="Last Credit Limit Date",
+        tracking=True,
     )
     risk_remaining_value = fields.Monetary(
         compute="_compute_risk_remaining",

--- a/account_financial_risk/readme/CONFIGURE.rst
+++ b/account_financial_risk/readme/CONFIGURE.rst
@@ -4,3 +4,5 @@ To configure this module, you need to:
 #. Go to *Invoicing/Accounting > Configuration > Settings > Accounting*
 #. In the *Customer Payments* section, fill *Maturity Margin* for setting the
    number of days to last after the due date to consider an invoice as unpaid.
+
+If you want an email to be sent when risk is exceeded in invoices, go to *Invoicing/Accounting > Configuration > Settings > Financial Risk* and fill the field `Email template sent when confirming invoice risk`.

--- a/account_financial_risk/readme/CONTRIBUTORS.rst
+++ b/account_financial_risk/readme/CONTRIBUTORS.rst
@@ -11,3 +11,7 @@
 * `Ooops404 <https://www.ooops404.com>`__:
 
   * Ilyas <irazor147@gmail.com>
+
+* `Aion Tech <https://aiontech.company/>`_:
+
+  * Simone Rubino <simone.rubino@aion-tech.it>

--- a/account_financial_risk/static/description/index.html
+++ b/account_financial_risk/static/description/index.html
@@ -403,6 +403,7 @@ displayed next to the credit limit.</p>
 <li>In the <em>Customer Payments</em> section, fill <em>Maturity Margin</em> for setting the
 number of days to last after the due date to consider an invoice as unpaid.</li>
 </ol>
+<p>If you want an email to be sent when risk is exceeded in invoices, go to <em>Invoicing/Accounting &gt; Configuration &gt; Settings &gt; Financial Risk</em> and fill the field <cite>Email template sent when confirming invoice risk</cite>.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
@@ -448,6 +449,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Ugne Sinkeviciene &lt;<a class="reference external" href="mailto:ugne&#64;versada.eu">ugne&#64;versada.eu</a>&gt;</li>
 <li><a class="reference external" href="https://www.ooops404.com">Ooops404</a>:<ul>
 <li>Ilyas &lt;<a class="reference external" href="mailto:irazor147&#64;gmail.com">irazor147&#64;gmail.com</a>&gt;</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/account_financial_risk/views/res_config_view.xml
+++ b/account_financial_risk/views/res_config_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2016-2018 Tecnativa - Carlos Dauden
+     Copyright 2024 Simone Rubino - Aion Tech
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="res_config_settings_view_form" model="ir.ui.view">
@@ -42,6 +43,29 @@
                             Useful when the flow comes from sales orders and the
                                 over-risk
                             has already been allowed when confirming these.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane" />
+                        <div class="o_setting_right_pane">
+                            <label for="account_move_confirm_risk_template_id" />
+                            <span
+                                class="fa fa-lg fa-building-o"
+                                title="Values set here are company-specific."
+                                role="img"
+                                aria-label="Values set here are company-specific."
+                                groups="base.group_multi_company"
+                            />
+                            <div class="text-muted">
+                                This email template is sent when the 'Partner risk exceeded wizard' for an invoice is confirmed.
+                            </div>
+                            <div class="content-group">
+                                <div class="row mt16 ml4">
+                                    <field
+                                        name="account_move_confirm_risk_template_id"
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Allow to send a configurable email template when risk for an invoice is explicitly exceeded in the wizard.

Also track the credit limit date because it is just as important as the amount (that is already tracked).