### PR TITLE
[16.0][FIX] account_financial_risk: Old group used instead of new group_account_financial_risk_user

### DIFF
--- a/account_financial_risk/views/res_partner_view.xml
+++ b/account_financial_risk/views/res_partner_view.xml
@@ -13,7 +13,7 @@
                     name="financial_risk"
                     string="Financial Risk"
                     attrs="{'invisible': [('is_company','=',False), ('parent_id','!=',False)]}"
-                    groups="account.group_account_manager"
+                    groups="account_financial_risk.group_account_financial_risk_user"
                 >
                     <group name="risk_general">
                         <group name="risk_include" class="o_group_col_6">


### PR DESCRIPTION
At this FW-Port group change was missed: https://github.com/OCA/credit-control/pull/298
This PR recovery the missed change

@Tecnativa TT50799
ping @sergio-teruel @victoralmau 