### PR TITLE
[15.0][FIX] account_invoice_overdue_reminder: add sudo() to mail.mail create

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -565,7 +565,7 @@ class OverdueReminderStep(models.TransientModel):
         )
         mvals.pop("attachment_ids", None)
         mvals.pop("attachments", None)
-        mail = self.env["mail.mail"].create(mvals)
+        mail = self.env["mail.mail"].sudo().create(mvals)
         inv_report = self.env["ir.actions.report"]._get_report_from_name(
             "account.report_invoice_with_payments"
         )


### PR DESCRIPTION
without the use of sudo() only administrators are allowed to use the module