### PR TITLE
[IMP] Add a config and a hook to sort moves using partner or residual  amount

### DIFF
--- a/account_invoice_overdue_reminder/models/res_company.py
+++ b/account_invoice_overdue_reminder/models/res_company.py
@@ -27,6 +27,9 @@ class ResCompany(models.Model):
         default="last_reminder",
         string="Contact to Remind",
     )
+    overdue_reminder_sort_by_amount = fields.Boolean(
+        string="Sort Overdue reminder by remaining amount", default=True
+    )
 
     @api.model
     def _overdue_reminder_interface_selection(self):

--- a/account_invoice_overdue_reminder/wizard/res_config_settings.py
+++ b/account_invoice_overdue_reminder/wizard/res_config_settings.py
@@ -23,3 +23,7 @@ class ResConfigSettings(models.TransientModel):
     overdue_reminder_partner_policy = fields.Selection(
         related="company_id.overdue_reminder_partner_policy", readonly=False
     )
+
+    overdue_reminder_sort_by_amount = fields.Boolean(
+        related="company_id.overdue_reminder_sort_by_amount", readonly=False
+    )

--- a/account_invoice_overdue_reminder/wizard/res_config_settings_view.xml
+++ b/account_invoice_overdue_reminder/wizard/res_config_settings_view.xml
@@ -38,16 +38,23 @@
                         class="col-12 col-md-12 o_setting_box"
                         id="overdue_reminder_sort_by_amount"
                     >
-                        <div class="o_setting_left_pane">
-                                <field name="overdue_reminder_sort_by_amount" />
-                        </div>
+                    <div class="o_setting_left_pane">
+                            <field name="overdue_reminder_sort_by_amount" />
+                    </div>
                     <div class="o_setting_right_pane">
                         <div class="row" name="overdue_reminder_sort_by_amount">
                             <label
                                     for="overdue_reminder_sort_by_amount"
-                                    class="col-md-5"
+                                    class="col-md-4"
                                 />
-                    </div>
+                                <span
+                                    class="fa fa-lg fa-building-o col-md-1"
+                                    title="Values set here are company-specific."
+                                    aria-label="Values set here are company-specific."
+                                    groups="base.group_multi_company"
+                                    role="img"
+                                />
+                        </div>
                     </div>
                 </div>
                 <div

--- a/account_invoice_overdue_reminder/wizard/res_config_settings_view.xml
+++ b/account_invoice_overdue_reminder/wizard/res_config_settings_view.xml
@@ -36,6 +36,22 @@
                 </div>
                 <div
                         class="col-12 col-md-12 o_setting_box"
+                        id="overdue_reminder_sort_by_amount"
+                    >
+                        <div class="o_setting_left_pane">
+                                <field name="overdue_reminder_sort_by_amount" />
+                        </div>
+                    <div class="o_setting_right_pane">
+                        <div class="row" name="overdue_reminder_sort_by_amount">
+                            <label
+                                    for="overdue_reminder_sort_by_amount"
+                                    class="col-md-5"
+                                />
+                    </div>
+                    </div>
+                </div>
+                <div
+                        class="col-12 col-md-12 o_setting_box"
                         id="overdue_reminder_other_fields"
                     >
                         <div class="o_setting_left_pane" />


### PR DESCRIPTION
 The initial behavior was only planned for the use of the residual amount as a sorting criterion.
One might need to sort by partner instead. This hook allows us to change the sorting using a config parameter