### PR TITLE
[FIX]accoount_credit_control: Fix Partner smart button to show all re…

### DIFF
--- a/account_credit_control/views/res_partner.xml
+++ b/account_credit_control/views/res_partner.xml
@@ -11,8 +11,8 @@
         <field name="res_model">credit.control.line</field>
         <field name="binding_model_id" ref="base.model_res_partner" />
         <field name="binding_view_types">form</field>
-        <field name="target">new</field>
-        <field name="view_mode">form</field>
+        <field name="target">current</field>
+        <field name="view_mode">tree,form</field>
     </record>
 
     <record id="partner_view_buttons" model="ir.ui.view">


### PR DESCRIPTION
…lated credit control lines.

I see that since version 15, the button action explicitly specifies that it should open a single record in form view, which doesn't make sense. The button might display 5 credit lines associated with a partner, but then there’s no way to view all 5."