### PR TITLE
[16.0][FIX] account_credit_control: Cancel orders without permissions

### DIFF
--- a/account_credit_control/models/account_move.py
+++ b/account_credit_control/models/account_move.py
@@ -35,14 +35,12 @@ class AccountMove(models.Model):
     def button_cancel(self):
         """Prevent to cancel invoice related to credit line"""
         # We will search if this invoice is linked with credit
-        cc_line_obj = self.env["credit.control.line"]
+        cc_line_obj = self.env["credit.control.line"].sudo()
         nondraft_domain = [
             ("invoice_id", "in", self.ids),
             ("state", "!=", "draft"),
         ]
-
         cc_nondraft_lines = cc_line_obj.search(nondraft_domain, limit=1)
-
         if cc_nondraft_lines:
             raise UserError(
                 _(


### PR DESCRIPTION
### Module

account_credit_control

### Describe the bug

It is not possible to cancel quotations with no invoices created without Credit Control and Invoicing permissions

### To Reproduce

1. Create a sale order
2. Try to cancel

(image from runboat OCA)

![image](https://github.com/user-attachments/assets/04b7df9a-fee7-4751-a524-d4ab09191b18)

![image](https://github.com/user-attachments/assets/bff68598-1dfc-46b9-b649-1a3efbf9aeb5)

![image](https://github.com/user-attachments/assets/29138082-141e-4fcf-a5d1-b50a1d6ceed3)

**Affected versions:**

16.0