### PR TITLE
[14.0][FIX] account_invoice_overdue_reminder:  fix wizard overdue reminder total_residual

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -644,7 +644,7 @@ class OverdueReminderStep(models.TransientModel):
     def total_residual(self):
         self.ensure_one()
         res = defaultdict(float)
-        for inv in self.invoice_ids:
+        for inv in self.get_invoices():
             res[inv.currency_id] += inv.amount_residual * (
                 inv.move_type == "out_refund" and -1 or 1
             )


### PR DESCRIPTION
Following this request: https://github.com/OCA/credit-control/pull/406
Total residual wasn't compute too. (after delete an invoice reminder line)
This PR propose a fix.