### PR TITLE
[14.0][FIX][sale_financial_risk] compute of risk_sale_order write on commercial partner

### DIFF
--- a/sale_financial_risk/models/res_partner.py
+++ b/sale_financial_risk/models/res_partner.py
@@ -26,7 +26,7 @@ class ResPartner(models.Model):
         risk_states = self.env["sale.order"]._get_risk_states()
         return self._get_risk_company_domain() + [
             ("state", "in", risk_states),
-            ("risk_partner_id", "in", self.mapped("commercial_partner_id").ids),
+            ("risk_partner_id", "in", self.ids),
         ]
 
     @api.depends(


### PR DESCRIPTION
Compute of risk_sale_order write on commercial_partner_id, not on self. 
cc @sebastienbeau , @alexis-via 