### PR TITLE
[16.0][FIX] account_invoice_overdue_reminder: access error

### DIFF
--- a/account_invoice_overdue_reminder/views/account_move.xml
+++ b/account_invoice_overdue_reminder/views/account_move.xml
@@ -35,19 +35,22 @@
                     name="overdue_reminder"
                     string="Overdue Reminder"
                     attrs="{'invisible': [('overdue', '=', False)]}"
+                    groups="account.group_account_invoice,account.group_account_readonly"
                 >
                 <group name="overdue_reminder_main" col="4">
                     <field name="overdue_reminder_counter" />
                     <field name="no_overdue_reminder" />
-                    <field name="commercial_partner_id" invisible="1" />
-                    <field name="overdue" invisible="1" />
-                    <field name="overdue_remind_sent" invisible="1" />
                 </group>
                 <group name="overdue_reminder_lines">
                     <field name="overdue_reminder_ids" nolabel="1" colspan="2" />
                 </group>
             </page>
         </notebook>
+        <field name="id" position="after">
+            <field name="overdue" invisible="1" />
+            <field name="overdue_remind_sent" invisible="1" />
+            <field name="no_overdue_reminder" invisible="1" />
+        </field>
     </field>
 </record>
 


### PR DESCRIPTION
When a purchase user that is NOT part of the invoicing group creates a vendor bill from a purchase order and the module account_invoice_overdue_reminder is installed, he has this error:

![bug_reminder](https://github.com/user-attachments/assets/30f504f5-30ff-4d07-bcb6-f86fef412e50)
