### PR TITLE
[16.0][IMP] account_financial_risk: Avoid same priority than account.view_move_line_pivot

### DIFF
--- a/account_financial_risk/views/account_financial_risk_view.xml
+++ b/account_financial_risk/views/account_financial_risk_view.xml
@@ -3,6 +3,7 @@
     <record id="financial_risk_account_move_line_pivot_view" model="ir.ui.view">
         <field name="name">Account financial risk account move line pivot view</field>
         <field name="model">account.move.line</field>
+        <field name="priority">999</field>
         <field name="arch" type="xml">
             <pivot string="Account move lines">
                 <field name="account_id" type="row" />


### PR DESCRIPTION
because account.action_account_moves_all have not defined view and it may be the case that the one in this module is used when it should not be.

@Tecnativa TT54575