### PR TITLE
[17.0][FIX] account_credit_control: Render invoice details in emails correctly

### DIFF
--- a/account_credit_control/models/credit_control_communication.py
+++ b/account_credit_control/models/credit_control_communication.py
@@ -128,6 +128,9 @@ class CreditControlCommunication(models.Model):
         """Aggregate credit control line by partner, level, and currency"""
         if not lines:
             return []
+        # Needed for related stored fields
+        # are recomputed before executing the SQL
+        lines.flush_recordset()
         sql = (
             "SELECT distinct partner_id, policy_level_id, "
             " credit_control_line.currency_id, "


### PR DESCRIPTION
Before this commit, the existing code was obsolete because, in V17, the `body` field is computed, and `_onchange_template_id` no longer exists. This commit adapts the code to correctly include invoice details in the email body.

Complementary to PR https://github.com/OCA/credit-control/pull/369
TT54881
@Tecnativa @victoralmau @sergio-teruel @pedrobaeza could you please review this
