### PR TITLE
[17.0][FIX] account_credit_control: Avoid error when opening or creating a mail template

### DIFF
--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -273,7 +273,7 @@ class CreditControlPolicyLevel(models.Model):
     delay_days = fields.Integer(string="Delay (in days)", required=True)
     email_template_id = fields.Many2one(
         comodel_name="mail.template",
-        domain=[("model_id.model", "=", "credit.control.communication")],
+        domain=[("model", "=", "credit.control.communication")],
         required=True,
     )
     channel = fields.Selection(selection=CHANNEL_LIST, required=True)

--- a/account_credit_control/views/credit_control_policy.xml
+++ b/account_credit_control/views/credit_control_policy.xml
@@ -45,6 +45,7 @@
                                         <group colspan="2">
                                             <field
                                                 name="email_template_id"
+                                                context="{'default_model': 'credit.control.communication'}"
                                                 colspan="2"
                                             />
                                             <field name="custom_text" colspan="2" />


### PR DESCRIPTION
When a user with the `group_account_credit_control_manager` group tries to select a `mail.template`, an access error is raised because `model_id(ir.model)` has permissions restricted to `Administration/Access Rights`. Instead of using a many2one field, the `model` field is used, as it is `related` and `stored`.


![image](https://github.com/user-attachments/assets/575d0000-8d18-43c4-a6ae-72e8674afc80)


TT55104
@Tecnativa @pedrobaeza @sergio-teruel could you please review this?