### PR TITLE
[17.0][IMP] account_credit_control: Add Credit control subtype in partners to auto-subscribe in credit control lines

### DIFF
--- a/account_credit_control/README.rst
+++ b/account_credit_control/README.rst
@@ -65,13 +65,13 @@ Control Lines* menu.
 
 On each generated line, you have many choices:
 
-- Send a email
-- Print a letter
-- Change the state (so you can ignore or reopen lines)
-- Mark a line as Manually Overridden. The line will get the ignored
-  state when a second credit control run is done.
-- Mark one line as Manual followup will also mark all the lines of the
-  partner. The partner will be visible in "Do Manual Follow-ups".
+-  Send a email
+-  Print a letter
+-  Change the state (so you can ignore or reopen lines)
+-  Mark a line as Manually Overridden. The line will get the ignored
+   state when a second credit control run is done.
+-  Mark one line as Manual followup will also mark all the lines of the
+   partner. The partner will be visible in "Do Manual Follow-ups".
 
 Once your lines are properly set up, go back to the "run" and click on
 *Run channel action* to massively generate and queue communication
@@ -79,6 +79,9 @@ emails or letters for all linked lines.
 
 Then, use the *Communications* smart button to see all email
 communication processes that have been created and follow them.
+
+The 'Credit Control' followers of the linked partner will be
+automatically added as followers to the credit control lines.
 
 Bug Tracker
 ===========
@@ -105,29 +108,29 @@ Authors
 Contributors
 ------------
 
-- Nicolas Bessi (Camptocamp)
-- Guewen Baconnier (Camptocamp)
-- Sylvain Van Hoof (Okia SPRL) <sylvain@okia.be>
-- Akim Juillerat (Camptocamp) <akim.juillerat@camptocamp.com>
-- Kinner Vachhani (Access Bookings Ltd) <kin.vachhani@gmail.com>
-- Raf Ven <raf.ven@dynapps.be>
-- Quentin Groulard (ACSONE) <quentin.groulard@acsone.eu>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Nicolas Bessi (Camptocamp)
+-  Guewen Baconnier (Camptocamp)
+-  Sylvain Van Hoof (Okia SPRL) <sylvain@okia.be>
+-  Akim Juillerat (Camptocamp) <akim.juillerat@camptocamp.com>
+-  Kinner Vachhani (Access Bookings Ltd) <kin.vachhani@gmail.com>
+-  Raf Ven <raf.ven@dynapps.be>
+-  Quentin Groulard (ACSONE) <quentin.groulard@acsone.eu>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Vicent Cubells
-  - Manuel Calero
-  - Ernesto Tejeda
-  - Pedro M. Baeza
-  - Jairo Llopis
-  - João Marques
-  - César A. Sánchez
-  - Víctor Martínez
+   -  Vicent Cubells
+   -  Manuel Calero
+   -  Ernesto Tejeda
+   -  Pedro M. Baeza
+   -  Jairo Llopis
+   -  João Marques
+   -  César A. Sánchez
+   -  Víctor Martínez
 
-- Enric Tobella <etobella@creublanca.es>
-- Naglis Jonaitis (Versada UAB) <naglis@versada.eu>
-- `360ERP <https://www.360erp.com>`__:
+-  Enric Tobella <etobella@creublanca.es>
+-  Naglis Jonaitis (Versada UAB) <naglis@versada.eu>
+-  `360ERP <https://www.360erp.com>`__:
 
-  - Andrea Stirpe
+   -  Andrea Stirpe
 
 Maintainers
 -----------

--- a/account_credit_control/data/data.xml
+++ b/account_credit_control/data/data.xml
@@ -223,4 +223,9 @@ Best regards
         <field name="hidden" eval="False" />
         <field name="internal" eval="False" />
     </record>
+    <record id="mt_credit_control_new" model="mail.message.subtype">
+        <field name="name">Credit control</field>
+        <field name="res_model">res.partner</field>
+        <field name="default" eval="False" />
+    </record>
 </odoo>

--- a/account_credit_control/readme/USAGE.md
+++ b/account_credit_control/readme/USAGE.md
@@ -21,3 +21,6 @@ emails or letters for all linked lines.
 
 Then, use the *Communications* smart button to see all email
 communication processes that have been created and follow them.
+
+The 'Credit Control' followers of the linked partner will be automatically
+added as followers to the credit control lines.

--- a/account_credit_control/static/description/index.html
+++ b/account_credit_control/static/description/index.html
@@ -422,6 +422,8 @@ partner. The partner will be visible in “Do Manual Follow-ups”.</li>
 emails or letters for all linked lines.</p>
 <p>Then, use the <em>Communications</em> smart button to see all email
 communication processes that have been created and follow them.</p>
+<p>The ‘Credit Control’ followers of the linked partner will be
+automatically added as followers to the credit control lines.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>


### PR DESCRIPTION
Add `Credit control` subtype in partners to auto-subscribe in credit control lines.

Please @sergio-teruel and @pedrobaeza can you review it?

@Tecnativa TT55207