### PR TITLE
[18.0][FIX] account_financial_risk: Display the Financial Risk page correct…

### DIFF
--- a/account_financial_risk/views/res_partner_view.xml
+++ b/account_financial_risk/views/res_partner_view.xml
@@ -12,7 +12,7 @@
                 <page
                     name="financial_risk"
                     string="Financial Risk"
-                    invisible="not is_company and not parent_id"
+                    invisible="not is_company and parent_id"
                     groups="account_financial_risk.group_account_financial_risk_user"
                 >
                     <group name="risk_general">


### PR DESCRIPTION
…ly when the contact is a person but does not have a parent_id.

During migration to V17, the conversion from attribute to Python expression was incorrect. As a result, this page became visible when a contact is a person but has a parent_id. The correct logic should display the field only when the contact is a person and does not have a parent_id.

fw-port of https://github.com/OCA/credit-control/pull/441

@pedrobaeza @carlosdauden @sergio-teruel could you please review this?