### PR TITLE
[17.0][FIX] account_credit_control: put the credit lines in error if mail was blacklisted

### DIFF
--- a/account_credit_control/models/mail_mail.py
+++ b/account_credit_control/models/mail_mail.py
@@ -8,10 +8,7 @@ from odoo import models
 class Mail(models.Model):
     _inherit = "mail.mail"
 
-    def _postprocess_sent_message(
-        self, success_pids, failure_reason=False, failure_type=None
-    ):
-        """Mark credit control lines states."""
+    def _update_control_line_status(self):
         for mail in self:
             msg = mail.mail_message_id
             if msg.model != "credit.control.communication":
@@ -23,8 +20,34 @@ class Mail(models.Model):
                 )
                 new_state = "sent" if mail.state == "sent" else "email_error"
                 lines.write({"state": new_state})
+
+    def _postprocess_sent_message(
+        self, success_pids, failure_reason=False, failure_type=None
+    ):
+        """Mark credit control lines states."""
+        self._update_control_line_status()
         return super()._postprocess_sent_message(
             success_pids=success_pids,
             failure_reason=failure_reason,
             failure_type=failure_type,
+        )
+
+    def _send(
+        self,
+        auto_commit=False,
+        raise_exception=False,
+        smtp_session=None,
+        alias_domain_id=False,
+    ):
+        # because of
+        # https://github.com/odoo/odoo/blob/bcba6c0dda4818e67a9023beb26593a7d74ff6a6/
+        # addons/mail/models/mail_mail.py#L606-L607
+        # we don't go through _postprocess_sent_message if the address is blacklisted
+        no_postprocess = self.filtered(lambda m: m.state != "outgoing")
+        no_postprocess._update_control_line_status()
+        return super()._send(
+            auto_commit=auto_commit,
+            raise_exception=raise_exception,
+            smtp_session=smtp_session,
+            alias_domain_id=alias_domain_id,
         )


### PR DESCRIPTION
Before, if the contact email is balcklisted, the control lines just appear as "queued" forever, even if the mail was canceled. This is due to postprocess not being called.