### PR TITLE
[18.0][FIX] account_financial_risk: better format res_partner_view

### DIFF
--- a/account_financial_risk/views/res_partner_view.xml
+++ b/account_financial_risk/views/res_partner_view.xml
@@ -21,7 +21,7 @@
                                 col="3"
                                 class="oe_subtotal_footer"
                                 string="General Limits"
-                                style="float: left !important;"
+                                style="float: left !important; border-top: none;"
                             >
                                 <field
                                     name="risk_invoice_draft_include"
@@ -30,7 +30,7 @@
                                 <button
                                     name="open_risk_pivot_info"
                                     type="object"
-                                    class="btn-link"
+                                    class="btn-link pt-0"
                                     context="{'open_risk_field': 'risk_invoice_draft'}"
                                 >
                                     <field
@@ -47,7 +47,7 @@
                                 <button
                                     name="open_risk_pivot_info"
                                     type="object"
-                                    class="btn-link"
+                                    class="btn-link pt-0"
                                     context="{'open_risk_field': 'risk_invoice_open'}"
                                 >
                                     <field
@@ -64,7 +64,7 @@
                                 <button
                                     name="open_risk_pivot_info"
                                     type="object"
-                                    class="btn-link"
+                                    class="btn-link pt-0"
                                     context="{'open_risk_field': 'risk_invoice_unpaid'}"
                                 >
                                     <field
@@ -81,7 +81,7 @@
                                 <button
                                     name="open_risk_pivot_info"
                                     type="object"
-                                    class="btn-link"
+                                    class="btn-link pt-0"
                                     context="{'open_risk_field': 'risk_account_amount'}"
                                 >
                                     <field
@@ -98,7 +98,7 @@
                                 <button
                                     name="open_risk_pivot_info"
                                     type="object"
-                                    class="btn-link"
+                                    class="btn-link pt-0"
                                     context="{'open_risk_field': 'risk_account_amount_unpaid'}"
                                 >
                                     <field
@@ -139,14 +139,11 @@
                                 />
                             </group>
                         </group>
-                        <group
-                            string="Specific Limits"
-                            name="risk_limits"
-                            class="o_group_col_6"
-                        >
+                        <group name="risk_limits" class="o_group_col_6">
                             <group
                                 class="oe_subtotal_footer"
-                                style="float: left !important;"
+                                string="Specific Limits"
+                                style="float: left !important; border-top: none; "
                             >
                                 <field
                                     name="risk_invoice_draft_limit"
@@ -184,8 +181,8 @@
                     </group>
                     <group string="Info">
                         <group>
-                            <div class="oe_inline" colspan="2">
-                                <label class="oe_inline" for="credit_currency" />
+                            <label class="o_label" for="credit_currency" />
+                            <div class="oe_inline">
                                 <field
                                     class="oe_inline"
                                     name="credit_currency"


### PR DESCRIPTION
In testing this module for v18 a few view inconsistencies became apparent.

- Extra border from oe_subtotal_footer on top or below.
- Groups a bit different in the way the two were declared.
- Buttons not inline with labels.
- Credit currency field was declared inside a div with label, much better outside.

This is a quick fix to make it presentable. In future we probably need to stop using oe_subtotal_footer and look to custom css.


Before:
![image](https://github.com/user-attachments/assets/397d87fc-f11e-46f2-976d-18933a37811e)

![image](https://github.com/user-attachments/assets/67e1dd28-0b3a-49c2-91b9-8a240d520059)


After:
![image](https://github.com/user-attachments/assets/1baa5402-4114-4fde-abb7-561e53889014)

![image](https://github.com/user-attachments/assets/1e5c2a1b-f03d-4bf3-a4a2-bca3100ba973)
