### PR TITLE
[18.0][FIX] sale_financial_risk: better format res_partner_view

### DIFF
--- a/sale_financial_risk/views/res_partner_view.xml
+++ b/sale_financial_risk/views/res_partner_view.xml
@@ -12,7 +12,7 @@
                 <button
                     name="open_risk_pivot_info"
                     type="object"
-                    class="btn-link"
+                    class="btn-link pt-0"
                     context="{'open_risk_field': 'risk_sale_order'}"
                 >
                     <field


### PR DESCRIPTION
Follows on from #448 to raise the sale order limit button to be inline.