### PR TITLE
[18.0][FIX] sale_financial_risk: rounding where uom is missing (eg. down payments)

### DIFF
--- a/sale_financial_risk/models/sale.py
+++ b/sale_financial_risk/models/sale.py
@@ -104,7 +104,8 @@ class SaleOrderLine(models.Model):
             if line.product_id.invoice_policy == "delivery":
                 qty = max(qty, line.qty_delivered)
             risk_qty = float_round(
-                qty - line.qty_invoiced, precision_rounding=line.product_uom.rounding
+                qty - line.qty_invoiced,
+                precision_rounding=line.product_uom.rounding or 0.01,
             )
             # There is no risk if the line hasn't stock moves to deliver
             # Added hasattr condition because fails in post-migration compute


### PR DESCRIPTION
Prevent this error (reproducible in runboat):

```
  File "/mnt/data/odoo-addons-dir/sale_financial_risk/models/sale.py", line 106, in _compute_risk_amount
    risk_qty = float_round(
  File "/opt/odoo/odoo/tools/float_utils.py", line 70, in float_round
    rounding_factor = _float_check_precision(precision_digits=precision_digits,
  File "/opt/odoo/odoo/tools/float_utils.py", line 35, in _float_check_precision
    assert precision_rounding > 0,\
AssertionError: precision_rounding must be positive, got 0.0
```