### PR TITLE
[18.0][FIX] account_financial_risk: Use .sudo() to access credit_limit to avoid side effects

### DIFF
--- a/account_financial_risk/models/res_partner.py
+++ b/account_financial_risk/models/res_partner.py
@@ -450,7 +450,8 @@ class ResPartner(models.Model):
                     amount_exceeded += field_value - max_value
                 if include:
                     amount += field_value
-            if partner.credit_limit and amount > partner.credit_limit:
+            credit_limit = partner.sudo().credit_limit
+            if credit_limit and amount > credit_limit:
                 risk_exception = True
                 amount_exceeded = amount - partner.credit_limit
             partner.risk_total = amount


### PR DESCRIPTION
Use `sudo()` to access `credit_limit` to avoid side effects.

Steps to reproduce the error:
- Install the `sale_financial_risk` module
- Install a sales module and run tests to confirm an order (`product_sold_by_delivery_week`, for example)

An error similar to this will be displayed:

```
File "/opt/odoo/auto/addons/account_financial_risk/models/res_partner.py", line 453, in _compute_risk_exception
    if partner.credit_limit and amount > partner.credit_limit:
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1266, in __get__
    recs._fetch_field(self)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4085, in _fetch_field
    self.check_field_access_rights('read', [field.name])
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3817, in check_field_access_rights
    raise AccessError(error_msg)
odoo.exceptions.AccessError: You do not have enough rights to access the fields "credit_limit" on Contact (res.partner). Please contact your system administrator.
```

What's the error?
The fields added by `sale_financial_risk` https://github.com/OCA/credit-control/blob/63730c2082b63ac2cf83f8b1add64420b712ed0f/sale_financial_risk/models/res_partner.py#L67C9-L67C25 are set to depend on `_get_depends_compute_risk_exception()` https://github.com/OCA/credit-control/blob/63730c2082b63ac2cf83f8b1add64420b712ed0f/account_financial_risk/models/res_partner.py#L503 , which causes the `_compute_risk_exception()` method to fail because the credit_limit field is not accessible. https://github.com/OCA/credit-control/blob/63730c2082b63ac2cf83f8b1add64420b712ed0f/account_financial_risk/models/res_partner.py#L441

The correct way to resolve this is to use `sudo()` to access `credit_limit`.

@Tecnativa