### PR TITLE
[15.0][FIX] account_credit_control: Use _for_xml_id() to avoid access errors

### DIFF
--- a/account_credit_control/models/credit_control_line.py
+++ b/account_credit_control/models/credit_control_line.py
@@ -294,9 +294,10 @@ class CreditControlLine(models.Model):
 
     def button_credit_control_line_form(self):
         self.ensure_one()
-        action = self.env.ref("account_credit_control.credit_control_line_action")
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account_credit_control.credit_control_line_action"
+        )
         form = self.env.ref("account_credit_control.credit_control_line_form")
-        action = action.read()[0]
         action["views"] = [(form.id, "form")]
         action["res_id"] = self.id
         return action

--- a/account_credit_control/models/credit_control_run.py
+++ b/account_credit_control/models/credit_control_run.py
@@ -182,10 +182,9 @@ class CreditControlRun(models.Model):
     def open_credit_communications(self):
         """Open the generated communications."""
         self.ensure_one()
-        action = self.env.ref(
+        action = self.env["ir.actions.act_window"]._for_xml_id(
             "account_credit_control.credit_control_communication_action"
         )
-        action = action.read()[0]
         action["domain"] = [
             ("id", "in", self.mapped("line_ids.communication_id").ids),
         ]
@@ -194,9 +193,9 @@ class CreditControlRun(models.Model):
     def open_credit_lines(self):
         """Open the generated lines"""
         self.ensure_one()
-        action_name = "account_credit_control.credit_control_line_action"
-        action = self.env.ref(action_name)
-        action = action.read()[0]
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account_credit_control.credit_control_line_action"
+        )
         action["domain"] = [("id", "in", self.line_ids.ids)]
         return action
 

--- a/account_credit_control/wizard/credit_control_policy_changer.py
+++ b/account_credit_control/wizard/credit_control_policy_changer.py
@@ -135,8 +135,8 @@ class CreditControlPolicyChanger(models.TransientModel):
         if not generated_lines:
             return {"type": "ir.actions.act_window_close"}
 
-        action_ref = "account_credit_control.credit_control_line_action"
-        action = self.env.ref(action_ref)
-        action = action.read()[0]
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account_credit_control.credit_control_line_action"
+        )
         action["domain"] = [("id", "in", generated_lines.ids)]
         return action


### PR DESCRIPTION
Use `_for_xml_id()` to avoid access errors

Please @pedrobaeza can you review it?

@Tecnativa TT57165