### PR TITLE
[16.0][FIX] account_credit_control: Use _for_xml_id() to avoid access errors

### DIFF
--- a/account_credit_control/models/credit_control_line.py
+++ b/account_credit_control/models/credit_control_line.py
@@ -294,9 +294,10 @@ class CreditControlLine(models.Model):
 
     def button_credit_control_line_form(self):
         self.ensure_one()
-        action = self.env.ref("account_credit_control.credit_control_line_action")
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account_credit_control.credit_control_line_action"
+        )
         form = self.env.ref("account_credit_control.credit_control_line_form")
-        action = action.read()[0]
         action["views"] = [(form.id, "form")]
         action["res_id"] = self.id
         return action

--- a/account_credit_control/wizard/credit_control_policy_changer.py
+++ b/account_credit_control/wizard/credit_control_policy_changer.py
@@ -135,8 +135,8 @@ class CreditControlPolicyChanger(models.TransientModel):
         if not generated_lines:
             return {"type": "ir.actions.act_window_close"}
 
-        action_ref = "account_credit_control.credit_control_line_action"
-        action = self.env.ref(action_ref)
-        action = action.read()[0]
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account_credit_control.credit_control_line_action"
+        )
         action["domain"] = [("id", "in", generated_lines.ids)]
         return action


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/credit-control/pull/471

Use `_for_xml_id()` to avoid access errors

Please @pedrobaeza can you review it?

@Tecnativa TT57165