### PR TITLE
[IMP] account_financial_risk: Remove store parameter from two fields …

### DIFF
--- a/account_financial_risk/models/res_partner.py
+++ b/account_financial_risk/models/res_partner.py
@@ -150,13 +150,11 @@ class ResPartner(models.Model):
         compute="_compute_risk_remaining",
         string="Risk Remaining (Value)",
         currency_field="risk_currency_id",
-        store=True,
     )
 
     risk_remaining_percentage = fields.Float(
         compute="_compute_risk_remaining",
         string="Risk Remaining (Percentage)",
-        store=True,
     )
 
     @api.depends("credit_limit", "risk_total")


### PR DESCRIPTION
…that depend on a non-stored field

backport of https://github.com/OCA/credit-control/pull/317

cc @carlosdauden 