### PR TITLE
[18.0][FIX] account_financial_risk: Fix access rights on credit_limit

### DIFF
--- a/account_financial_risk/models/account_invoice.py
+++ b/account_financial_risk/models/account_invoice.py
@@ -54,7 +54,7 @@ class AccountMove(models.Model):
         elif not partner.risk_invoice_draft_include and (
             partner.risk_invoice_open_include
             and (partner.risk_total + self.risk_amount_total_currency)
-            > partner.credit_limit
+            > partner.sudo().credit_limit
         ):
             exception_msg = self.env._("This invoice exceeds the financial risk.\n")
         return exception_msg

--- a/account_financial_risk/models/res_partner.py
+++ b/account_financial_risk/models/res_partner.py
@@ -198,20 +198,19 @@ class ResPartner(models.Model):
 
     @api.depends("credit_limit")
     def _compute_date_credit_limit(self):
-        self.filtered(lambda x: x.credit_limit == 0.00).date_credit_limit = False
+        self.filtered(lambda x: x.sudo().credit_limit == 0.00).date_credit_limit = False
         self.filtered(
-            lambda x: x.credit_limit != 0.00
+            lambda x: x.sudo().credit_limit != 0.00
         ).date_credit_limit = datetime.today()
 
     @api.depends("credit_limit", "risk_total")
     def _compute_risk_remaining(self):
         for record in self:
-            record.risk_remaining_value = record.credit_limit - record.risk_total
-            if record.credit_limit:
+            credit_limit = record.sudo().credit_limit
+            record.risk_remaining_value = credit_limit - record.risk_total
+            if credit_limit:
                 record.risk_remaining_percentage = round(
-                    100
-                    * (record.credit_limit - record.risk_total)
-                    / record.credit_limit,
+                    100 * (credit_limit - record.risk_total) / credit_limit,
                     2,
                 )
             else:
@@ -481,7 +480,7 @@ class ResPartner(models.Model):
             credit_limit = partner.sudo().credit_limit
             if credit_limit and amount > credit_limit:
                 risk_exception = True
-                amount_exceeded = amount - partner.credit_limit
+                amount_exceeded = amount - credit_limit
             partner.risk_total = amount
             partner.risk_amount_exceeded = amount_exceeded
             partner.risk_exception = risk_exception

--- a/account_financial_risk/tests/test_account_financial_risk.py
+++ b/account_financial_risk/tests/test_account_financial_risk.py
@@ -14,7 +14,6 @@ class TestPartnerFinancialRisk(BaseCommon):
     def setUpClass(cls):
         super().setUpClass()
         (cls.env.ref("base.USD") | cls.env.ref("base.EUR")).active = True
-        cls.env.user.groups_id |= cls.env.ref("account.group_account_manager")
         cls.env.user.groups_id |= cls.env.ref(
             "account_financial_risk.group_account_financial_risk_manager"
         )

--- a/partner_risk_insurance/models/res_partner.py
+++ b/partner_risk_insurance/models/res_partner.py
@@ -70,14 +70,14 @@ class ResPartner(models.Model):
     def _compute_company_credit_limit(self):
         for partner in self:
             partner.company_credit_limit = max(
-                0, (partner.credit_limit - partner.insurance_credit_limit)
+                0, (partner.sudo().credit_limit - partner.insurance_credit_limit)
             )
 
     @api.onchange("insurance_credit_limit")
     def _onchange_insurance_credit_limit_update_total_limit(self):
         """Set the total limit to the insurance limit if it is greater."""
-        if self.insurance_credit_limit > self.credit_limit:
-            self.credit_limit = self.insurance_credit_limit
+        if self.insurance_credit_limit > self.sudo().credit_limit:
+            self.sudo().credit_limit = self.insurance_credit_limit
 
     @api.onchange("use_partner_credit_limit")
     def _onchange_use_partner_credit_limit(self):

--- a/sale_financial_risk/models/sale.py
+++ b/sale_financial_risk/models/sale.py
@@ -29,7 +29,7 @@ class SaleOrder(models.Model):
                 "This sale order exceeds the sales orders risk.\n"
             )
         elif partner.risk_sale_order_include and (
-            (partner.risk_total + risk_amount) > partner.credit_limit
+            (partner.risk_total + risk_amount) > partner.sudo().credit_limit
         ):
             exception_msg = self.env._("This sale order exceeds the financial risk.\n")
         return exception_msg

--- a/sale_financial_risk_info/models/sale.py
+++ b/sale_financial_risk_info/models/sale.py
@@ -24,10 +24,11 @@ class SaleOrder(models.Model):
         )
         for sale in self:
             partner = sale.partner_invoice_id.commercial_partner_id
-            if not partner.credit_limit:
+            credit_limit = partner.sudo().credit_limit
+            if not credit_limit:
                 sale.risk_info = _("Unlimited")
                 continue
-            risk_percent = round(partner.risk_total / partner.credit_limit * 100)
+            risk_percent = round(partner.risk_total / credit_limit * 100)
             if risk_percent >= partner.risk_percent_warning:
                 text_class = ' class="text-danger"'
             else:
@@ -38,12 +39,12 @@ class SaleOrder(models.Model):
                     self.env, partner.risk_total, partner.risk_currency_id
                 ),
                 credit_limit=format_amount(
-                    self.env, partner.credit_limit, partner.risk_currency_id
+                    self.env, credit_limit, partner.risk_currency_id
                 ),
                 risk_percent=risk_percent,
                 risk_available=format_amount(
                     self.env,
-                    partner.credit_limit - partner.risk_total,
+                    credit_limit - partner.risk_total,
                     partner.risk_currency_id,
                 ),
             )


### PR DESCRIPTION
When users without accounting access are trying to access a Sale Order, they have an access error on the partner field credit_limit (standard Odoo field that is limited to Account groups), which is used when computing the SO's risk_info. This is fixed by adding the group financial_risk_user to the field. Now the user can access the SO, and sees the risk_info if they have the financial_risk_user right, otherwise it is not displayed, with no access error.