### PR TITLE
[16.0][IMP] account_invoice_overdue_reminder: optimize identification of unreconciled lines

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -228,9 +228,7 @@ class OverdueReminderStart(models.TransientModel):
         unrec_domain = [
             ("account_id", "=", commercial_partner.property_account_receivable_id.id),
             ("partner_id", "=", commercial_partner.id),
-            ("full_reconcile_id", "=", False),
-            ("matched_debit_ids", "=", False),
-            ("matched_credit_ids", "=", False),
+            ("matching_number", "=", False),
         ]
         unrec_payments = amlo.search(
             unrec_domain


### PR DESCRIPTION
# Description

On big a big database, I realized that writing:
```python
("full_reconcile_id", "=", False),
("matched_debit_ids", "=", False),
("matched_credit_ids", "=", False),
```
 results to a SQL filter:
```sql
("account_move_line"."full_reconcile_id" IS NULL )
AND
(
  "account_move_line"."id" not in (
      SELECT
          "credit_move_id"
      FROM
          "account_partial_reconcile"
      WHERE
          "credit_move_id" IS NOT NULL
 )
) AND (
  "account_move_line"."id" not in (
    SELECT
        "debit_move_id"
    FROM
        "account_partial_reconcile"
    WHERE
        "debit_move_id" IS NOT NULL
 )
)
```
But, this *where clause* could be simplified to `"matching_number", "=", False` which is way simpler and easier to plan for the postgres scheduler.

This results in a query that is executed faster!