### PR TITLE
[17.0][FIX] sale_financial_risk: Use the assert_called_once() method to avoid errors in tests

### DIFF
--- a/sale_financial_risk/tests/test_payment_financial_risk.py
+++ b/sale_financial_risk/tests/test_payment_financial_risk.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from unittest.mock import ANY, patch
+from unittest.mock import patch
 
 from odoo.fields import Command
 from odoo.tests import tagged
@@ -67,7 +67,7 @@ class TestRiskSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
             "._compute_show_tokenize_input_mapping"
         ) as patched:
             tx_context = self._get_portal_pay_context(**route_values)
-            patched.assert_called_once_with(ANY, sale_order_id=ANY)
+            patched.assert_called_once()
         tx_route_values = {
             "provider_id": self.provider.id,
             "payment_method_id": self.payment_method_id,


### PR DESCRIPTION
Backport from 18.0: https://github.com/OCA/credit-control/pull/485

Use the `assert_called_once()` method to avoid errors in tests

Use the same method that appears in sale test: https://github.com/odoo/odoo/blob/11f702df0b8eb4186e93f713aba427b6ddcbf3b0/addons/sale/tests/test_payment_flow.py#L42

```
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/sale_financial_risk/tests/test_payment_financial_risk.py", line 70, in test_payment_risk_bypass
    patched.assert_called_once_with(ANY, sale_order_id=ANY)
  File "/usr/local/lib/python3.10/unittest/mock.py", line 941, in assert_called_once_with
    return self.assert_called_with(*args, **kwargs)
  File "/usr/local/lib/python3.10/unittest/mock.py", line 929, in assert_called_with
    raise AssertionError(_error_message()) from cause
AssertionError: expected call not found.
Expected: _compute_show_tokenize_input_mapping(<ANY>, sale_order_id=<ANY>) Actual: _compute_show_tokenize_input_mapping(payment.provider(18,), website_id=1, sale_order_id=91)
```

Please @pedrobaeza can you review it?

@Tecnativa