### PR TITLE
[18.0][IMP] account_credit_control - multi-channel policies

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Credit Control",
-    "version": "18.0.2.0.0",
+    "version": "18.0.3.0.0",
     "author": "Camptocamp,"
     "Odoo Community Association (OCA),"
     "Okia,"

--- a/account_credit_control/data/data.xml
+++ b/account_credit_control/data/data.xml
@@ -37,7 +37,7 @@
         <field name="delay_days" eval="0" />
         <field name="email_template_id" ref="email_template_credit_control_base" />
         <field name="policy_id" ref="credit_control_no_follow" />
-        <field name="channel">email</field>
+        <field name="channel_email" eval="1" />
         <field name="custom_text">Manual no follow</field>
         <field name="custom_mail_text">Manual no follow</field>
     </record>
@@ -52,7 +52,7 @@
         <field name="delay_days" eval="10" />
         <field name="email_template_id" ref="email_template_credit_control_base" />
         <field name="policy_id" ref="credit_control_3_time" />
-        <field name="channel">email</field>
+        <field name="channel_email" eval="1" />
         <field
             name="custom_text"
         >Our records indicate that we have not received the payment of the invoice mentioned below.
@@ -81,7 +81,7 @@ Best regards
         <field name="delay_days" eval="30" />
         <field name="email_template_id" ref="email_template_credit_control_base" />
         <field name="policy_id" ref="credit_control_3_time" />
-        <field name="channel">email</field>
+        <field name="channel_email" eval="1" />
         <field
             name="custom_text"
         >Our records indicate that we have not yet received the payment of the invoice mentioned below despite our first reminder.
@@ -111,7 +111,7 @@ Best regards
         <field name="delay_days" eval="10" />
         <field name="email_template_id" ref="email_template_credit_control_base" />
         <field name="policy_id" ref="credit_control_3_time" />
-        <field name="channel">letter</field>
+        <field name="channel_letter" eval="1" />
         <field name="custom_text">
 Our records indicate that we still have not received the payment of the invoice mentioned below despite our two reminders.
 If payment have already been sent, please disregard this notice. If not, please proceed with payment.
@@ -153,7 +153,7 @@ Best regards
         <field name="delay_days" eval="30" />
         <field name="email_template_id" ref="email_template_credit_control_base" />
         <field name="policy_id" ref="credit_control_2_time" />
-        <field name="channel">email</field>
+        <field name="channel_email" eval="1" />
         <field
             name="custom_text"
         >Our records indicate that we have not received the payment of the invoice mentioned below.
@@ -182,7 +182,7 @@ Best regards
         <field name="delay_days" eval="60" />
         <field name="email_template_id" ref="email_template_credit_control_base" />
         <field name="policy_id" ref="credit_control_2_time" />
-        <field name="channel">letter</field>
+        <field name="channel_letter" eval="1" />
         <field
             name="custom_text"
         >Our records indicate that we still have not received the payment of the mentioned below invoice despite our reminder.

--- a/account_credit_control/migrations/18.0.3.0.0/post-migration.py
+++ b/account_credit_control/migrations/18.0.3.0.0/post-migration.py
@@ -1,0 +1,31 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cr = env.cr
+    if openupgrade.column_exists(cr, "credit_control_line", "channel"):
+        openupgrade.map_values(
+            cr,
+            "channel_old",
+            "channel_letter",
+            [("letter", "t")],
+            table="credit_control_line",
+        )
+        openupgrade.map_values(
+            cr,
+            "channel_old",
+            "channel_email",
+            [("email", "t")],
+            table="credit_control_line",
+        )
+        openupgrade.map_values(
+            cr,
+            "channel_old",
+            "channel_phone",
+            [("phone", "t")],
+            table="credit_control_line",
+        )

--- a/account_credit_control/migrations/18.0.3.0.0/post-migration.py
+++ b/account_credit_control/migrations/18.0.3.0.0/post-migration.py
@@ -7,7 +7,7 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     cr = env.cr
-    if openupgrade.column_exists(cr, "credit_control_line", "channel"):
+    if openupgrade.column_exists(cr, "credit_control_line", "channel_old"):
         openupgrade.map_values(
             cr,
             "channel_old",
@@ -28,4 +28,26 @@ def migrate(env, version):
             "channel_phone",
             [("phone", "t")],
             table="credit_control_line",
+        )
+    if openupgrade.column_exists(cr, "credit_control_policy", "channel_old"):
+        openupgrade.map_values(
+            cr,
+            "channel_old",
+            "channel_letter",
+            [("letter", "t")],
+            table="credit_control_policy",
+        )
+        openupgrade.map_values(
+            cr,
+            "channel_old",
+            "channel_email",
+            [("email", "t")],
+            table="credit_control_policy",
+        )
+        openupgrade.map_values(
+            cr,
+            "channel_old",
+            "channel_phone",
+            [("phone", "t")],
+            table="credit_control_policy",
         )

--- a/account_credit_control/migrations/18.0.3.0.0/pre-migration.py
+++ b/account_credit_control/migrations/18.0.3.0.0/pre-migration.py
@@ -14,6 +14,15 @@ def migrate(env, version):
             {
                 "credit_control_line": [
                     ("channel", "channel_old", None),
-                ]
+                ],
+            },
+        )
+    if openupgrade.column_exists(env.cr, "credit_control_policy", "channel"):
+        openupgrade.copy_columns(
+            env.cr,
+            {
+                "credit_control_policy": [
+                    ("channel", "channel_old", None),
+                ],
             },
         )

--- a/account_credit_control/migrations/18.0.3.0.0/pre-migration.py
+++ b/account_credit_control/migrations/18.0.3.0.0/pre-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Preserve channel historic data from credit.control.line records
+    if openupgrade.column_exists(env.cr, "credit_control_line", "channel"):
+        openupgrade.copy_columns(
+            env.cr,
+            {
+                "credit_control_line": [
+                    ("channel", "channel_old", None),
+                ]
+            },
+        )

--- a/account_credit_control/models/credit_control_communication.py
+++ b/account_credit_control/models/credit_control_communication.py
@@ -247,7 +247,7 @@ class CreditControlCommunication(models.Model):
                 ),
             )
 
-    def _mark_credit_line_as_sent(self):
+    def _mark_credit_line_as_sent(self, channel):
         lines = self.mapped("credit_control_line_ids")
-        lines.write({"state": "sent"})
+        lines._set_sent(channel)
         return lines

--- a/account_credit_control/models/credit_control_line.py
+++ b/account_credit_control/models/credit_control_line.py
@@ -6,8 +6,6 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
-from .credit_control_policy import CHANNEL_LIST
-
 
 class CreditControlLine(models.Model):
     """A credit control line describes an amount due by a customer
@@ -62,11 +60,15 @@ class CreditControlLine(models.Model):
         "Draft and ignored lines will be "
         "generated again on the next run.",
     )
-    channel = fields.Selection(
-        selection=CHANNEL_LIST,
-        required=True,
-        readonly=False,
-    )
+
+    channel_email = fields.Boolean(string="By e-mail")
+    channel_letter = fields.Boolean(string="By post")
+    channel_phone = fields.Boolean(string="By phone")
+
+    email_sent = fields.Boolean()
+    letter_sent = fields.Boolean()
+    phone_sent = fields.Boolean()
+
     invoice_id = fields.Many2one(comodel_name="account.move", readonly=True)
     partner_id = fields.Many2one(
         comodel_name="res.partner",
@@ -163,18 +165,21 @@ class CreditControlLine(models.Model):
         self, move_line, level, controlling_date, open_amount, default_lines_vals
     ):
         """Create credit control line"""
-        channel = level.channel
+        channel_email = level.channel_email
+        channel_letter = level.channel_letter
         partner = move_line.partner_id
-        # Fallback to letter
-        if channel == "email" and partner and not partner.email:
-            channel = "letter"
+        # Fallback to letter on missing email address
+        if channel_email and partner and not partner.email:
+            channel_email = False
+            channel_letter = True
         data = default_lines_vals.copy()
         data.update(
             {
                 "date": controlling_date,
                 "date_due": move_line.date_maturity,
                 "state": "draft",
-                "channel": channel,
+                "channel_email": channel_email,
+                "channel_letter": channel_letter,
                 "invoice_id": (move_line.move_id.id if move_line.move_id else False),
                 "partner_id": partner.id,
                 "amount_due": (
@@ -272,6 +277,50 @@ class CreditControlLine(models.Model):
         lines_to_write.write({"state": "ignored"})
 
         return new_lines
+
+    def run_channel_letter(self):
+        if not self:
+            return
+        wiz = self.env["credit.control.printer"].create({"line_ids": self.ids})
+        wiz.print_lines()
+
+    def run_channel_email(self):
+        if not self:
+            return
+        comm_obj = self.env["credit.control.communication"]
+        comms = comm_obj._generate_comm_from_credit_lines(self)
+        comms._generate_emails()
+
+    def run_channel_action(self):
+        lines = self.filtered(lambda rec: rec.state == "to_be_sent")
+        letter_lines = lines.filtered("channel_letter")
+        letter_lines.run_channel_letter()
+
+        email_lines = lines.filtered("channel_email")
+        email_lines.run_channel_email()
+
+    def _channel_list(self):
+        return ["email", "letter", "phone"]
+
+    def _update_state_on_sent(self):
+        for rec in self:
+            sent = True
+            for chan in self._channel_list():
+                to_be_sent = rec[f"channel_{chan}"]
+                sent_ok = rec[f"{chan}_sent"]
+                if to_be_sent and not sent_ok:
+                    sent = False
+                    break
+            if sent:
+                rec.state = "sent"
+
+    def _set_sent(self, channel):
+        """Check all selected channels are done"""
+        channels = self._channel_list()
+        assert channel in channels
+        if channel:
+            self.write({f"{channel}_sent": True})
+        self._update_state_on_sent()
 
     def unlink(self):
         for line in self:

--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -8,8 +8,6 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 
-CHANNEL_LIST = [("letter", "Letter"), ("email", "Email"), ("phone", "Phone")]
-
 
 class CreditControlPolicy(models.Model):
     """Define a policy of reminder"""
@@ -320,7 +318,9 @@ class CreditControlPolicyLevel(models.Model):
         domain=[("model", "=", "credit.control.communication")],
         required=True,
     )
-    channel = fields.Selection(selection=CHANNEL_LIST, required=True)
+    channel_email = fields.Boolean(string="By e-mail")
+    channel_letter = fields.Boolean(string="By post")
+    channel_phone = fields.Boolean(string="By phone")
     custom_text = fields.Text(string="Custom Message", required=True, translate=True)
     mail_show_invoice_detail = fields.Boolean(string="Show Invoice Details in mail")
     custom_mail_text = fields.Html(

--- a/account_credit_control/models/credit_control_run.py
+++ b/account_credit_control/models/credit_control_run.py
@@ -155,7 +155,7 @@ class CreditControlRun(models.Model):
         """
         try:
             self.env.cr.execute(
-                "SELECT id FROM credit_control_run" " LIMIT 1 FOR UPDATE NOWAIT"
+                "SELECT id FROM credit_control_run LIMIT 1 FOR UPDATE NOWAIT"
             )
         except Exception as err:
             # In case of exception openerp will do a rollback
@@ -200,16 +200,4 @@ class CreditControlRun(models.Model):
         self.hide_change_state_button = True
 
     def run_channel_action(self):
-        self.ensure_one()
-        lines = self.line_ids.filtered(lambda x: x.state == "to_be_sent")
-        letter_lines = lines.filtered(lambda x: x.channel == "letter")
-        email_lines = lines.filtered(lambda x: x.channel == "email")
-        if email_lines:
-            comm_obj = self.env["credit.control.communication"]
-            comms = comm_obj._generate_comm_from_credit_lines(email_lines)
-            comms._generate_emails()
-        if letter_lines:
-            wiz = self.env["credit.control.printer"].create(
-                {"line_ids": letter_lines.ids}
-            )
-            return wiz.print_lines
+        self.mapped("line_ids").run_channel_action()

--- a/account_credit_control/models/mail_mail.py
+++ b/account_credit_control/models/mail_mail.py
@@ -18,8 +18,10 @@ class Mail(models.Model):
                 lines = self.env["credit.control.line"].search(
                     [("communication_id", "=", msg.res_id), ("state", "=", "queued")]
                 )
-                new_state = "sent" if mail.state == "sent" else "email_error"
-                lines.write({"state": new_state})
+                if mail.state == "sent":
+                    lines._set_sent("email")
+                else:
+                    lines.write({"state": "email_error"})
 
     def _postprocess_sent_message(
         self, success_pids, failure_reason=False, failure_type=None

--- a/account_credit_control/tests/test_credit_control_run.py
+++ b/account_credit_control/tests/test_credit_control_run.py
@@ -333,6 +333,94 @@ class TestCreditControlRun(TestCreditControlRunCase):
         self.assertNotIn("Invoices summary", new_communication.message_ids.body)
         self.assertNotIn(self.invoice.name, new_communication.message_ids.body)
 
+    def test_sent_multi_channel_email_letter(self):
+        """
+        Verify lines sent states changes
+        """
+        policy_level = self.env.ref("account_credit_control.3_time_1")
+        policy_level.channel_letter = True
+        policy_level.channel_email = True
+
+        # assign a email to ensure does not fallback to letter
+        self.invoice.partner_id.email = "test@test.com"
+        control_run = self.env["credit.control.run"].create(
+            {"date": fields.Date.today(), "policy_ids": [(6, 0, [self.policy.id])]}
+        )
+        control_run.with_context(lang="en_US").generate_credit_lines()
+        self.assertTrue(len(self.invoice.credit_control_line_ids), 1)
+        control_lines = self.invoice.credit_control_line_ids
+
+        marker = self.env["credit.control.marker"].create(
+            {"name": "to_be_sent", "line_ids": [(6, 0, control_lines.ids)]}
+        )
+        marker.mark_lines()
+
+        # Send the email
+        self.env.user.company_id.email = "test@example.com"
+        emailer_obj = self.env["credit.control.emailer"]
+        wiz_emailer = emailer_obj.create({})
+        wiz_emailer.line_ids = control_lines
+        wiz_emailer.email_lines()
+
+        self.assertEqual(control_lines[0].state, "queued")
+        self.assertEqual(control_lines[0].email_sent, True)
+        self.assertEqual(control_lines[0].letter_sent, False)
+
+        # Print the PDF
+        printer_obj = self.env["credit.control.printer"]
+        wiz_printer = printer_obj.with_context(
+            active_model="credit.control.line", active_ids=control_lines.ids
+        ).create({})
+        wiz_printer.print_lines()
+
+        self.assertEqual(control_lines[0].state, "sent")
+        self.assertEqual(control_lines[0].email_sent, True)
+        self.assertEqual(control_lines[0].letter_sent, True)
+
+    def test_sent_multi_channel_letter_email(self):
+        """
+        Verify lines sent states changes
+        """
+        policy_level = self.env.ref("account_credit_control.3_time_1")
+        policy_level.channel_letter = True
+        policy_level.channel_email = True
+
+        # assign a email to ensure does not fallback to letter
+        self.invoice.partner_id.email = "test@test.com"
+        control_run = self.env["credit.control.run"].create(
+            {"date": fields.Date.today(), "policy_ids": [(6, 0, [self.policy.id])]}
+        )
+        control_run.with_context(lang="en_US").generate_credit_lines()
+        self.assertTrue(len(self.invoice.credit_control_line_ids), 1)
+        control_lines = self.invoice.credit_control_line_ids
+
+        marker = self.env["credit.control.marker"].create(
+            {"name": "to_be_sent", "line_ids": [(6, 0, control_lines.ids)]}
+        )
+        marker.mark_lines()
+
+        # Print the PDF
+        printer_obj = self.env["credit.control.printer"]
+        wiz_printer = printer_obj.with_context(
+            active_model="credit.control.line", active_ids=control_lines.ids
+        ).create({})
+        wiz_printer.print_lines()
+
+        self.assertEqual(control_lines[0].state, "to_be_sent")
+        self.assertEqual(control_lines[0].email_sent, False)
+        self.assertEqual(control_lines[0].letter_sent, True)
+
+        # Send the email
+        self.env.user.company_id.email = "test@example.com"
+        emailer_obj = self.env["credit.control.emailer"]
+        wiz_emailer = emailer_obj.create({})
+        wiz_emailer.line_ids = control_lines
+        wiz_emailer.email_lines()
+
+        self.assertEqual(control_lines[0].state, "queue")
+        self.assertEqual(control_lines[0].email_sent, True)
+        self.assertEqual(control_lines[0].letter_sent, True)
+
     def test_open_credit_lines(self):
         """
         Test access rights when invoking method open_credit_lines

--- a/account_credit_control/views/account_move.xml
+++ b/account_credit_control/views/account_move.xml
@@ -34,7 +34,9 @@
                             <field name="date" />
                             <field name="level" />
                             <field name="state" />
-                            <field name="channel" />
+                            <field name="channel_email" />
+                            <field name="channel_letter" />
+                            <field name="channel_phone" />
                             <field name="balance_due" />
                             <field name="policy_level_id" />
                             <field name="policy_id" />

--- a/account_credit_control/views/credit_control_communication.xml
+++ b/account_credit_control/views/credit_control_communication.xml
@@ -39,7 +39,9 @@
                             <field name="date" />
                             <field name="level" />
                             <field name="state" />
-                            <field name="channel" />
+                            <field name="channel_email" />
+                            <field name="channel_letter" />
+                            <field name="channel_phone" />
                             <field name="balance_due" />
                             <field name="policy_level_id" />
                             <field name="policy_id" />

--- a/account_credit_control/views/credit_control_line.xml
+++ b/account_credit_control/views/credit_control_line.xml
@@ -21,11 +21,66 @@
                             <field name="level" />
                             <field name="manually_overridden" />
                         </group>
+                        <group string="Channels" name="channels">
+                            <label for="channel_email" />
+                            <div>
+                                <field
+                                    name="channel_email"
+                                    class="oe_inline"
+                                    readonly="state != 'draft'"
+                                />
+                                <i
+                                    class="fa fa-paper-plane fa-fw"
+                                    title="Email sent?"
+                                />
+                                <field
+                                    name="email_sent"
+                                    readonly="state != 'draft'"
+                                    nolabel="1"
+                                    class="oe_inline"
+                                />
+                            </div>
+                            <label for="channel_letter" />
+                            <div>
+                                <field
+                                    name="channel_letter"
+                                    class="oe_inline"
+                                    readonly="state != 'draft'"
+                                />
+                                <i
+                                    class="fa fa-paper-plane fa-fw"
+                                    title="Letter sent?"
+                                />
+                                <field
+                                    name="letter_sent"
+                                    class="oe_inline"
+                                    nolabel="1"
+                                    readonly="state != 'draft'"
+                                />
+                            </div>
+                            <label for="channel_phone" />
+                            <div>
+                                <field
+                                    name="channel_phone"
+                                    class="oe_inline"
+                                    readonly="state != 'draft'"
+                                />
+                                <i
+                                    class="fa fa-paper-plane fa-fw"
+                                    title="Phone done?"
+                                />
+                                <field
+                                    name="phone_sent"
+                                    class="oe_inline"
+                                    readonly="state != 'draft'"
+                                    nolabel="1"
+                                />
+                            </div>
+                        </group>
                         <group>
                             <field name="date" readonly="state != 'draft'" />
                             <field name="date_entry" />
                             <field name="date_due" readonly="state != 'draft'" />
-                            <field name="channel" readonly="state != 'draft'" />
                             <field name="date_sent" readonly="state != 'draft'" />
                             <field name="communication_id" />
                         </group>
@@ -57,7 +112,9 @@
             <search>
                 <group>
                     <field name="date" />
-                    <field name="channel" />
+                    <field name="channel_email" />
+                    <field name="channel_letter" />
+                    <field name="channel_phone" />
                     <field name="policy_id" />
                     <separator />
                     <field name="partner_id" />
@@ -155,12 +212,6 @@
                         string="Credit policy level"
                     />
                     <filter
-                        name="group_by_channel"
-                        domain='[]'
-                        context="{'group_by': 'channel'}"
-                        string="Channel"
-                    />
-                    <filter
                         name="group_by_overridden"
                         domain='[]'
                         context="{'group_by': 'manually_overridden'}"
@@ -198,7 +249,9 @@
                 <field name="level" />
                 <field name="manually_overridden" readonly="state != 'draft'" />
                 <field name="state" />
-                <field name="channel" readonly="state != 'draft'" />
+                <field name="channel_email" readonly="state != 'draft'" />
+                <field name="channel_letter" readonly="state != 'draft'" />
+                <field name="channel_phone" readonly="state != 'draft'" />
                 <field name="invoice_id" />
                 <field name="partner_id" readonly="True" />
                 <field name="manual_followup" />

--- a/account_credit_control/views/credit_control_policy.xml
+++ b/account_credit_control/views/credit_control_policy.xml
@@ -33,7 +33,9 @@
                                 <list>
                                     <field name="name" />
                                     <field name="level" />
-                                    <field name="channel" />
+                                    <field name="channel_email" />
+                                    <field name="channel_letter" />
+                                    <field name="channel_phone" />
                                     <field name="delay_days" />
                                     <field name="computation_mode" />
                                     <field name="email_template_id" />
@@ -44,9 +46,13 @@
                                         <page string="Delay Setting">
                                             <group>
                                                 <field name="level" />
-                                                <field name="channel" />
                                                 <field name="delay_days" />
                                                 <field name="computation_mode" />
+                                            </group>
+                                            <group string="Channels" name="channels">
+                                                <field name="channel_email" />
+                                                <field name="channel_letter" />
+                                                <field name="channel_phone" />
                                             </group>
                                         </page>
                                         <page string="Mail and reporting">
@@ -63,7 +69,7 @@
                                                 />
                                                 <field
                                                     name="mail_show_invoice_detail"
-                                                    invisible="channel != 'email'"
+                                                    invisible="channel_email"
                                                     colspan="2"
                                                 />
                                                 <field
@@ -133,9 +139,13 @@
                     <page string="Delay Setting">
                         <group>
                             <field name="level" />
-                            <field name="channel" />
                             <field name="delay_days" />
                             <field name="computation_mode" />
+                        </group>
+                        <group string="Channels" name="channels">
+                            <field name="channel_email" />
+                            <field name="channel_letter" />
+                            <field name="channel_phone" />
                         </group>
                     </page>
                     <page string="Mail and reporting">
@@ -155,7 +165,9 @@
             <list>
                 <field name="name" />
                 <field name="level" />
-                <field name="channel" />
+                <field name="channel_email" />
+                <field name="channel_letter" />
+                <field name="channel_phone" />
                 <field name="delay_days" />
                 <field name="computation_mode" />
                 <field name="email_template_id" />

--- a/account_credit_control/wizard/credit_control_emailer.py
+++ b/account_credit_control/wizard/credit_control_emailer.py
@@ -29,7 +29,7 @@ class CreditControlEmailer(models.TransientModel):
         comodel_name="credit.control.line",
         string="Credit Control Lines",
         default=lambda self: self._get_line_ids(),
-        domain=[("state", "=", "to_be_sent"), ("channel", "=", "email")],
+        domain=[("state", "=", "to_be_sent"), ("channel_email", "=", True)],
     )
 
     @api.model
@@ -39,7 +39,7 @@ class CreditControlEmailer(models.TransientModel):
         domain = [
             ("state", "=", "to_be_sent"),
             ("id", "in", lines.ids),
-            ("channel", "=", "email"),
+            ("channel_email", "=", True),
         ]
         return line_obj.search(domain)
 

--- a/account_credit_control/wizard/credit_control_printer.py
+++ b/account_credit_control/wizard/credit_control_printer.py
@@ -51,7 +51,7 @@ class CreditControlPrinter(models.TransientModel):
         comms = comm_obj._generate_comm_from_credit_lines(lines)
 
         if self.mark_as_sent:
-            comms._mark_credit_line_as_sent()
+            comms._mark_credit_line_as_sent("letter")
 
         report_name = "account_credit_control.report_credit_control_summary"
         report_obj = self.env["ir.actions.report"]._get_report_from_name(report_name)

--- a/account_credit_control_attach_invoice/tests/test_ir_action_report.py
+++ b/account_credit_control_attach_invoice/tests/test_ir_action_report.py
@@ -39,7 +39,7 @@ class TestIrActionsReport(SavepointCaseWithUserDemo):
                 "computation_mode": "net_days",
                 "delay_days": 2,
                 "email_template_id": cls.mail_template.id,
-                "channel": "email",
+                "channel_email": True,
                 "custom_mail_text": "<t t-out='4 + 9'/>",
                 "custom_text": "<t t-out='4 + 9'/>",
             }
@@ -68,7 +68,7 @@ class TestIrActionsReport(SavepointCaseWithUserDemo):
                             "partner_id": cls.partner.id,
                             "move_line_id": cls.invoice.line_ids[0].id,
                             "policy_level_id": cls.credit_control_policy_level.id,
-                            "channel": "email",
+                            "channel_email": True,
                             "date": Datetime.now(),
                             "date_due": Datetime.now(),
                             "amount_due": 25,


### PR DESCRIPTION
(superseeded by #522 )

Adds the possibility to send reminders via multiple channels for the same level.

Sometimes you want to send reminders on multiple channels at the same time for instance send an email as well as sending a letter on high policy level.

This adds a checkbox for each channel.

Adding a new channel must be done by adding the following fields:

- `channel_<name>` on both `credit.control.line` and `credit.control.policy` 
- `<name>_sent` on `credit.control.line`

Line is updated to `sent` only after all selected channels have been processed. It is still possible to force the manually the state to sent to settle the line.

Policy level:

<img width="1689" height="754" alt="image" src="https://github.com/user-attachments/assets/70362d59-d23a-49bb-88a4-0b1b522d0072" />

Credit control line:

<img width="1201" height="599" alt="image" src="https://github.com/user-attachments/assets/01311fc5-6de7-45b5-9d5c-ac5aaf318720" />



TODO:

- [x] Rebase on top of #467 
- [x] Migration script to set channels