### PR TITLE
[15.0][IMP+FIX] account_credit_control: Defining the right data in the communication email

### DIFF
--- a/account_credit_control/models/credit_control_communication.py
+++ b/account_credit_control/models/credit_control_communication.py
@@ -188,7 +188,10 @@ class CreditControlCommunication(models.Model):
         table_content = "<br/><h3>%s</h3>" % _("Invoices summary")
         table_content += "<table style='%s'><tr>%s</tr>" % (table_style, tr_content)
         for line in self.credit_control_line_ids:
-            tr_content = "<td style='%s'>%s</td>" % (th_style, line.invoice_id.name)
+            name = line.invoice_id.name
+            if line.move_line_id.ref and line.move_line_id.ref != name:
+                name += f" ({line.move_line_id.ref})"
+            tr_content = "<td style='%s'>%s</td>" % (th_style, name)
             tr_content += "<td style='%s'>%s</td>" % (
                 th_style,
                 line.invoice_id.payment_reference or "",

--- a/account_credit_control/models/credit_control_communication.py
+++ b/account_credit_control/models/credit_control_communication.py
@@ -195,7 +195,7 @@ class CreditControlCommunication(models.Model):
             )
             tr_content += "<td style='%s'>%s</td>" % (
                 th_style,
-                format_date(self.env, line.invoice_id.invoice_date),
+                format_date(self.env, line.date_entry),
             )
             tr_content += "<td style='%s'>%s</td>" % (
                 th_style,
@@ -203,11 +203,11 @@ class CreditControlCommunication(models.Model):
             )
             tr_content += "<td style='%s'>%s</td>" % (
                 th_style,
-                format_amount(self.env, line.invoice_id.amount_total, line.currency_id),
+                format_amount(self.env, line.amount_due, line.currency_id),
             )
             tr_content += "<td style='%s'>%s</td>" % (
                 th_style,
-                format_amount(self.env, line.amount_due, line.currency_id),
+                format_amount(self.env, line.balance_due, line.currency_id),
             )
             table_content += "<tr>%s</tr>" % tr_content
         table_content += "</table>"

--- a/account_credit_control/report/report_credit_control_summary.xml
+++ b/account_credit_control/report/report_credit_control_summary.xml
@@ -40,6 +40,11 @@
                             <t t-if="l.invoice_id">
                                 <td>
                                     <span t-field="l.invoice_id.name" />
+                                    <t
+                                        t-if="l.move_line_id.ref and l.move_line_id.ref!=l.invoice_id.name"
+                                    >
+                                        (<span t-field="l.move_line_id.ref" />)
+                                    </t>
                                 </td>
                             </t>
                             <t t-if="not l.invoice_id">

--- a/account_credit_control/views/credit_control_line.xml
+++ b/account_credit_control/views/credit_control_line.xml
@@ -23,6 +23,7 @@
                         </group>
                         <group>
                             <field name="date" />
+                            <field name="date_entry" />
                             <field name="date_due" />
                             <field name="channel" />
                             <field name="date_sent" />
@@ -217,6 +218,7 @@
                     class="oe_stat_button"
                 />
                 <field name="date" />
+                <field name="date_entry" />
                 <field name="date_due" />
                 <field name="level" />
                 <field name="manually_overridden" />


### PR DESCRIPTION
Backport from 17.0: https://github.com/OCA/credit-control/pull/438

<ins>Defining the right data in the communication email.</ins>

Changes done:
- Defined date_entry for the Invoice date column.
- Define amount_due for Invoice amount column
- Set balance_due for the Amount Due column

This data is the same as already shown in the Credit Control Summary report.

<ins>Add `date_entry` field to lines views.</ins>

<ins>Define the appropriate value in Invoice number for moves.</ins>

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT57552