### PR TITLE
[FIX] account_credit_control_attach_invoice res_config_settings_view_…

### DIFF
--- a/account_credit_control_attach_invoice/views/res_config_settings.xml
+++ b/account_credit_control_attach_invoice/views/res_config_settings.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <record id="res_config_settings_view_form" model="ir.ui.view">
-        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field
+            name="inherit_id"
+            ref="account_credit_control.res_config_settings_view_form"
+        />
         <field name="model">res.config.settings</field>
         <field name="arch" type="xml">
             <block id="credit_control" position="inside">


### PR DESCRIPTION
…form

Fix broken view inheritance.

`<block id="credit_control" position="inside">`  belong to module account_credit_control