### PR TITLE
[18.0][IMP] account_credit_control: Report custom text fields in html

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Credit Control",
-    "version": "18.0.2.0.2",
+    "version": "18.0.2.1.0",
     "author": "Camptocamp,"
     "Odoo Community Association (OCA),"
     "Okia,"

--- a/account_credit_control/migrations/18.0.2.1.0/post-migration.py
+++ b/account_credit_control/migrations/18.0.2.1.0/post-migration.py
@@ -1,0 +1,35 @@
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    Convert custom_text fields to Html on policy_level
+    """
+    if (
+        env["credit.control.policy.level"]._fields["custom_text"].type != "html"
+        and env["credit.control.policy.level"]._fields["custom_text_after_details"].type
+        != "html"
+    ):
+        cr = env.cr
+        openupgrade.copy_columns(
+            cr,
+            {
+                "credit_control_policy_level": [
+                    ("custom_text", None, None),
+                    ("custom_text_after_details", None, None),
+                ]
+            },
+        )
+        openupgrade.convert_field_to_html(
+            cr, "credit_control_policy_level", "custom_text", "custom_text"
+        )
+        openupgrade.convert_field_to_html(
+            cr,
+            "credit_control_policy_level",
+            "custom_text_after_details",
+            "custom_text_after_details",
+        )

--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -321,12 +321,12 @@ class CreditControlPolicyLevel(models.Model):
         required=True,
     )
     channel = fields.Selection(selection=CHANNEL_LIST, required=True)
-    custom_text = fields.Text(string="Custom Message", required=True, translate=True)
+    custom_text = fields.Html(string="Custom Message", required=True, translate=True)
     mail_show_invoice_detail = fields.Boolean(string="Show Invoice Details in mail")
     custom_mail_text = fields.Html(
         string="Custom Mail Message", required=True, translate=True
     )
-    custom_text_after_details = fields.Text(
+    custom_text_after_details = fields.Html(
         string="Custom Message after details", translate=True
     )
 


### PR DESCRIPTION
Forward port of https://github.com/OCA/credit-control/pull/64

The aim of these two fields is to be injected in reports, thus it seems more convenient to me to have them in HTML.