### PR TITLE
[18.0][IMP] Copy mail body to chatter

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -628,10 +628,8 @@ class OverdueReminderStep(models.TransientModel):
                     body=Markup(
                         _(
                             "<strong>Overdue reminder</strong> sent by mail: "
-                            "<a href=# data-oe-model=mail.mail "
-                            "data-oe-id=%(mail_id)s>%(mail_subject)s</a>.",
-                            mail_id=vals["mail_id"],
-                            mail_subject=self.mail_subject,
+                            "%(mail_body)s",
+                            mail_body=str(self.mail_body),
                         )
                     )
                 )


### PR DESCRIPTION
This copy the mail directly into the chatter instead of putting the link to it to avoid issue with rights to the mail model.