### PR TITLE
[17.0][FIX] account_credit_control: Freeze test execution date to avoid time-dependent failures

### DIFF
--- a/account_credit_control/tests/test_credit_control_run.py
+++ b/account_credit_control/tests/test_credit_control_run.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime
 
 from dateutil import relativedelta
+from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import AccessError, UserError
@@ -19,6 +20,7 @@ from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 @tagged("post_install", "-at_install")
 class TestCreditControlRun(AccountTestInvoicingCommon):
     @classmethod
+    @freeze_time("2025-04-24")
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
         cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
@@ -136,6 +138,7 @@ class TestCreditControlRun(AccountTestInvoicingCommon):
         regex_result = re.match(report_regex, control_run.report)
         self.assertIsNotNone(regex_result)
 
+    @freeze_time("2025-04-24")
     def test_generate_credit_lines_with_max_level(self):
         """
         Test the method generate_credit_lines with max level group.


### PR DESCRIPTION
bp https://github.com/OCA/credit-control/pull/527

@Tecnativa 

@pedrobaeza  @victoralmau please review