### PR TITLE
[18.0][FIX] sale_financial_risk: avoid writing on commercial_partner during compute on partner

### DIFF
--- a/sale_financial_risk/models/res_partner.py
+++ b/sale_financial_risk/models/res_partner.py
@@ -27,7 +27,7 @@ class ResPartner(models.Model):
         risk_states = self.env["sale.order"]._get_risk_states()
         return self._get_risk_company_domain() + [
             ("state", "in", risk_states),
-            ("risk_partner_id", "in", self.mapped("commercial_partner_id").ids),
+            ("risk_partner_id", "in", self.ids),
         ]
 
     @api.depends(


### PR DESCRIPTION
Currently Odoo is writing on a commercial_partner when doing `_compute_risk_sale_order()` on a partner (two different records).

It is against the expected behavior of a non-stored readonly computed field and can create **security problems** as the commercial_partner record is not necessary accessible by the Odoo user who is accessing the current partner's record.

cc @sebastienbeau 