### PR TITLE
[18.0][FIX] partner_risk_insurance: error duplicate contact

### DIFF
--- a/partner_risk_insurance/models/res_partner.py
+++ b/partner_risk_insurance/models/res_partner.py
@@ -25,45 +25,54 @@ class ResPartner(models.Model):
             "It represents the amount of credit that an insurance policy guarantees."
         ),
         tracking=True,
+        copy=False,
     )
     risk_insurance_coverage_percent = fields.Float(
         "Insurance coverage (%)",
         groups="account.group_account_invoice,account.group_account_readonly",
         help="Percentage of the credit that is covered by the insurance.",
+        copy=False,
     )
     risk_insurance_requested = fields.Boolean(
         "Insurance Requested",
         help="Mark this field if an insurance was "
         "requested for the credit of this partner.",
+        copy=False,
     )
     risk_insurance_grant_date = fields.Date(
         "Insurance Grant Date",
         help="Date when the insurance was granted by the insurance company.",
+        copy=False,
     )
     risk_insurance_code = fields.Char(
         "Insurance Code",
         help="Code assigned to this partner by the risk insurance company.",
+        copy=False,
     )
     risk_insurance_code_2 = fields.Char(
         "Insurance Code 2",
         help="Secondary code assigned to this "
         "partner by the risk insurance "
         "company.",
+        copy=False,
     )
     credit_policy_state_id = fields.Many2one(
         string="Policy State",
         comodel_name="credit.policy.state",
         ondelete="restrict",
+        copy=False,
     )
     credit_policy_insure_invoices = fields.Boolean(
         string="Insure Invoices",
         related="credit_policy_state_id.insure_invoices",
         store=False,
+        copy=False,
     )
     credit_policy_company_id = fields.Many2one(
         string="Credit Policy Company",
         comodel_name="credit.policy.company",
         ondelete="restrict",
+        copy=False,
     )
 
     @api.depends("credit_limit", "insurance_credit_limit")


### PR DESCRIPTION
When attempting to duplicate a contact (`res.partner` model), users with limited invoice permissions receive a permission error. The duplication is not completed because the system attempts to read the `insurance_credit_limit` and `risk_insurance_coverage_percent` fields.
And I add `copy=False` for risk_insurance_requested, risk_insurance_grant_date, risk_insurance_code, risk_insurance_code_2.

<img width="1170" height="359" alt="Captura desde 2026-01-15 13-01-12" src="https://github.com/user-attachments/assets/7db4e050-0542-493c-b4d6-dda97d90cb8a" />
<img width="1905" height="896" alt="image" src="https://github.com/user-attachments/assets/2e5e3184-7b36-4d63-abf5-4b931525ae42" />


With this small fix we can duplicate a contact
<img width="1912" height="975" alt="image" src="https://github.com/user-attachments/assets/6426dcda-e315-4d55-9527-23d65a9d6a69" />


MT-13337
@moduon