### PR TITLE
[18.0][FIX] account_credit_control: Apply sudo() to avoid access error

### DIFF
--- a/account_credit_control/models/account_move.py
+++ b/account_credit_control/models/account_move.py
@@ -35,7 +35,10 @@ class AccountMove(models.Model):
     def button_cancel(self):
         """Prevent to cancel invoice related to credit line"""
         # We will search if this invoice is linked with credit
-        cc_line_obj = self.env["credit.control.line"]
+        # We must apply sudo() because the user may not have sufficient permissions
+        # to access credit.control.line (for example, a sales user when canceling
+        #  an order).
+        cc_line_obj = self.env["credit.control.line"].sudo()
         nondraft_domain = [
             ("invoice_id", "in", self.ids),
             ("state", "!=", "draft"),

--- a/sale_financial_risk/tests/test_partner_sale_risk.py
+++ b/sale_financial_risk/tests/test_partner_sale_risk.py
@@ -2,15 +2,15 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import fields
+from odoo.tests import new_test_user
 
-from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT, BaseCommon
+from odoo.addons.base.tests.common import BaseCommon
 
 
 class TestPartnerSaleRisk(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
         cls.env.user.groups_id |= cls.env.ref(
             "account_financial_risk.group_account_financial_risk_manager"
         )
@@ -86,6 +86,23 @@ class TestPartnerSaleRisk(BaseCommon):
         self.assertTrue(self.partner.risk_allow_edit)
         wiz.button_continue()
         self.assertAlmostEqual(self.partner.risk_sale_order, 230.0)
+        # Create invoice
+        invoice = sale_order2._create_invoices()
+        res = invoice.action_post()
+        wizard = self.env[res["res_model"]].browse(res["res_id"])
+        wizard.button_continue()
+        self.assertEqual(invoice.state, "posted")
+        # Cancel order + invoice with sale user
+        sale_user = new_test_user(
+            self.env,
+            login="test-sale_user",
+            groups="sales_team.group_sale_salesman_all_leads",
+        )
+        res = sale_order2.action_cancel()
+        wizard = self.env[res["res_model"]].with_context(**res["context"]).create({})
+        wizard = wizard.with_user(sale_user)
+        wizard.action_cancel()
+        self.assertEqual(sale_order2.state, "cancel")
 
     def test_sale_order_auto_done(self):
         self.env["ir.config_parameter"].create(


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/credit-control/pull/545

Apply `sudo()` to avoid access error + Add `sale_financial_risk` test use case

@Tecnativa TT61117