### PR TITLE
[18][IMP] account_invoice_overdue_reminder: remove domain on company child for cc emails 

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard_view.xml
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard_view.xml
@@ -215,7 +215,7 @@
                 <group name="mail" invisible="reminder_type != 'mail'">
                     <field
                         name="mail_cc_partner_ids"
-                        domain="[('id', 'child_of', commercial_partner_id), ('id', '!=', partner_id), ('email', '!=', False)]"
+                        domain="[('id', '!=', partner_id), ('email', '!=', False)]"
                         widget="many2many_tags"
                     />
                     <field name="mail_subject" />


### PR DESCRIPTION
As we may want to add some unrelated emails address, like internally, commercial responsible, etc

@alexis-via 