### PR TITLE
[18.0][IMP] account_invoice_overdue_reminder: subscribe the sender to the partner

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -588,6 +588,10 @@ class OverdueReminderStep(models.TransientModel):
         if self.company_id.overdue_reminder_attach_invoice:
             attachment_ids = self._get_attachment_ids(mail)
             mail.write({"attachment_ids": [Command.set(attachment_ids)]})
+        # to make sure the sender receives the potential answer
+        self.commercial_partner_id.message_subscribe(
+            partner_ids=[self.env.user.partner_id.id]
+        )
         vals = {"mail_id": mail.id}
         return vals
 


### PR DESCRIPTION
Auto-subscribe the sender to the partner to which the overdue reminder is sent by email, to make sure that the sender is notified of a potential answer.

This is a forward-port of #551 