### PR TITLE
[16.0][IMP] account_credit_control: Use same field types

### DIFF
--- a/account_credit_control/__manifest__.py
+++ b/account_credit_control/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Credit Control",
-    "version": "16.0.2.0.2",
+    "version": "16.0.2.1.0",
     "author": "Camptocamp,"
     "Odoo Community Association (OCA),"
     "Okia,"

--- a/account_credit_control/migrations/16.0.2.1.0/post-migrate.py
+++ b/account_credit_control/migrations/16.0.2.1.0/post-migrate.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    credit_control_lines = env["credit.control.policy.level"].search(
+        [("custom_mail_text", "!=", False)]
+    )
+    for ccl in credit_control_lines:
+        ccl.custom_mail_text = (
+            ccl.custom_mail_text.replace("&nbsp;", "")
+            .replace("<p>", "")
+            .replace("</p>", "\n")
+        )

--- a/account_credit_control/models/credit_control_policy.py
+++ b/account_credit_control/models/credit_control_policy.py
@@ -281,7 +281,7 @@ class CreditControlPolicyLevel(models.Model):
     channel = fields.Selection(selection=CHANNEL_LIST, required=True)
     custom_text = fields.Text(string="Custom Message", required=True, translate=True)
     mail_show_invoice_detail = fields.Boolean(string="Show Invoice Details in mail")
-    custom_mail_text = fields.Html(
+    custom_mail_text = fields.Text(
         string="Custom Mail Message", required=True, translate=True
     )
     custom_text_after_details = fields.Text(


### PR DESCRIPTION
Harmonize fields types for mail template texts