### PR TITLE
[18.0][FIX] account_credit_control: communication contact_address loop

### DIFF
--- a/account_credit_control/models/credit_control_communication.py
+++ b/account_credit_control/models/credit_control_communication.py
@@ -88,7 +88,7 @@ class CreditControlCommunication(models.Model):
             )
             if one.contact_address_id in partners:
                 # Contact is already child of partner
-                return
+                continue
             address_ids = one.partner_id.address_get(adr_pref=["invoice"])
             one.contact_address_id = address_ids["invoice"]
 


### PR DESCRIPTION
Make `_onchange_partner_id()` properly work on recordsets.