### PR TITLE
[18.0][FIX] account_invoice_overdue_reminder: only take into account posted journal entries for unreconciled warning

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -230,6 +230,7 @@ class OverdueReminderStart(models.TransientModel):
             ("full_reconcile_id", "=", False),
             ("matched_debit_ids", "=", False),
             ("matched_credit_ids", "=", False),
+            ("parent_state", "=", "posted"),
         ]
         unrec_payments = amlo.search(
             unrec_domain


### PR DESCRIPTION
Here is the scenario to reproduce the bug:
1) for customer X, create a customer invoice with a due date in the past and confirm it
2) for customer X, create a customer refund and **cancel** it
3) start overdue wizard

<img width="977" height="984" alt="overdue_bug" src="https://github.com/user-attachments/assets/404150b9-2756-4a48-974e-8e0d0b276017" />
