### PR TITLE
[FIX] account_invoice_overdue_reminder: use correct report action XML ID

### DIFF
--- a/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
+++ b/account_invoice_overdue_reminder/wizard/overdue_reminder_wizard.py
@@ -537,7 +537,7 @@ class OverdueReminderStep(models.TransientModel):
         iaro = self.env["ir.actions.report"]
         for inv in self.invoice_ids:
             report_bin, report_format = iaro._render(
-                "account.report_invoice_with_payments", [inv.id]
+                "account.account_invoices", [inv.id]
             )
             filename = f"{inv._get_report_base_filename()}.{report_format}"
             attach = iao.create(


### PR DESCRIPTION
The method _get_attachment_ids() was calling iaro._render() with 'account.report_invoice_with_payments', which is the XML ID of an ir.ui.view (QWeb template), not an ir.actions.report. Odoo 18 enforces a strict type check in ir.actions.report._get_report(), causing a ValueError at runtime.

Fix: use the correct ir.actions.report XML ID 'account.account_invoices' instead.