### PR TITLE
[16.0][FIX] account_credit_control: translate credit line table in emails

### DIFF
--- a/account_credit_control/models/credit_control_communication.py
+++ b/account_credit_control/models/credit_control_communication.py
@@ -176,6 +176,10 @@ class CreditControlCommunication(models.Model):
         return comms
 
     def _get_credit_control_communication_table(self):
+        # Force context to contact's language before rendering strings
+        lang = self.contact_address_id.lang or "en_US"
+        self = self.with_context(lang=lang)
+
         th_style = "padding: 5px; border: 1px solid black;"
         tr_content = "<th style='%s'>%s</th>" % (th_style, _("Invoice number"))
         tr_content += "<th style='%s'>%s</th>" % (th_style, _("Payment Reference"))

--- a/account_credit_control/tests/__init__.py
+++ b/account_credit_control/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_credit_control_policy
 from . import test_res_partner
 from . import test_account_move
 from . import test_credit_control_run
+from . import test_credit_control_communication_translation

--- a/account_credit_control/tests/test_credit_control_communication_translation.py
+++ b/account_credit_control/tests/test_credit_control_communication_translation.py
@@ -1,0 +1,66 @@
+# Copyright 2026 360ERP (<https://www.360erp.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+
+
+@tagged("post_install", "-at_install")
+class TestCreditControlCommunicationTranslation(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
+
+        # Activate Dutch language
+        cls.env["res.lang"]._activate_lang("nl_NL")
+
+        # Create partner with Dutch language set
+        cls.partner_nl = cls.env["res.partner"].create(
+            {
+                "name": "Dutch Test Partner",
+                "lang": "nl_NL",
+            }
+        )
+
+        # Setup policy and communication record
+        cls.policy = cls.env.ref("account_credit_control.credit_control_3_time")
+        cls.policy_level = cls.env.ref("account_credit_control.3_time_1")
+        cls.policy_level.mail_show_invoice_detail = True
+
+        cls.communication = cls.env["credit.control.communication"].create(
+            {
+                "partner_id": cls.partner_nl.id,
+                "contact_address_id": cls.partner_nl.id,
+                "policy_level_id": cls.policy_level.id,
+                "currency_id": cls.env.company.currency_id.id,
+                "company_id": cls.env.company.id,
+            }
+        )
+
+    def test_communication_table_language_propagation(self):
+        """Verify _get_credit_control_communication_table uses partner's lang."""
+        # Generate table
+        table_html = self.communication._get_credit_control_communication_table()
+
+        # Check headers that are reliably translated in the standard nl_NL locale
+        self.assertIn(
+            "Factuurnummer",
+            table_html,
+            "The context switch failed: 'Invoice number' was not translated.",
+        )
+        self.assertIn(
+            "Vervaldatum",
+            table_html,
+            "The context switch failed: 'Due date' was not translated.",
+        )
+
+    def test_communication_table_fallback_lang(self):
+        """Verify table falls back gracefully when contact has no lang set."""
+        self.partner_nl.lang = False
+        table_html = self.communication._get_credit_control_communication_table()
+
+        # Fallback to source English strings
+        self.assertIn("Invoices summary", table_html)


### PR DESCRIPTION
**Current behavior:**
When generating credit control emails with the `mail_show_invoice_detail` option enabled, the injected HTML table containing the invoice details ("Invoices summary", "Due date", etc.) is rendered in the language of the user triggering the action (or the cron user). It ignores the partner's configured language.

**Expected behavior:**
The injected table's headers, date formats, and currency formats should seamlessly match the language of the recipient, aligning with how the rest of the `mail.template` is translated.

**Proposed changes:**

* Updated `_get_credit_control_communication_table` in `credit.control.communication` to force the environment context to match `contact_address_id.lang` (falling back to `en_US`) before evaluating the `_("...")` gettext aliases and format helpers.
* This mimics the exact logic used in the `lang` field of the credit control mail templates.
* Added test coverage in `test_credit_control_communication_translation.py` to ensure the context propagation successfully translates the standard table headers.
