### PR TITLE
[19.0][FIX] sale_financial_risk: set require_signature=False in payment test

### DIFF
--- a/sale_financial_risk/tests/test_payment_financial_risk.py
+++ b/sale_financial_risk/tests/test_payment_financial_risk.py
@@ -93,6 +93,7 @@ class TestRiskSalePayment(AccountPaymentCommon, PaymentHttpCommon):
                 {
                     "partner_id": cls.partner.id,
                     "pricelist_id": cls.pricelist.id,
+                    "require_signature": False,
                     "order_line": [
                         Command.create(
                             {


### PR DESCRIPTION
[FIX] sale_financial_risk: set require_signature=False in payment test                                                                                                                                                   
                                                                                                                                                                                                                           
Odoo 19.0 (odoo/odoo#278854) made sale.payment.transaction                                                                                                                                                               
_check_amount_and_confirm_order check `_has_to_be_signed()`, so an online                                                                                                                                                
payment no longer auto-confirms a quotation that still requires an online                                                                                                                                                
signature. On databases where the company enables Online Signature, the                                                                                                                                                  
test order gets require_signature=True and stays in 'draft', breaking                                                                                                                                                    
test_payment_risk_bypass with 'draft' != 'sale'.                                                                                                                                                                         
                                                                                                                                                                                                                           
Disable signature on the test order, matching the fix odoo applied to its                                                                                                                                                own sale/pos tests, so the test isolates the risk-bypass behaviour it                                                                                                                                                    
actually checks. 