### PR TITLE
[16.0][FIX] account_invoice_overdue_reminder: wysiwig-friendly html code

### DIFF
--- a/account_invoice_overdue_reminder/data/mail_template.xml
+++ b/account_invoice_overdue_reminder/data/mail_template.xml
@@ -53,17 +53,15 @@
                             style="padding: 5px; border: 1px solid black;"
                         >Past Reminders</th>
                     </tr>
-                    <t
+                    <tr
                         t-foreach="object.invoice_ids.sorted(key='invoice_date')"
                         t-as="inv"
-                    >
-                        <tr
-                            style="background-color:
+                        style="background-color:
                             % if inv.move_type == 'out_refund':
                                 LightGray
                             % endif
                         "
-                        >
+                    >
                             <td style="padding: 5px; border: 1px solid black;">
                                 <t t-out="inv.name" />
                             </td>
@@ -80,36 +78,34 @@
                                 <t t-out="inv.ref or ''" />
                             </td>
                             <td style="padding: 5px; border: 1px solid black;"><t
-                                    t-out="dict(inv.fields_get(allfields=['move_type'])['move_type']['selection'])[inv.move_type]"
-                                /></td>
+                                t-out="dict(inv.fields_get(allfields=['move_type'])['move_type']['selection'])[inv.move_type]"
+                            /></td>
                             <td
-                                style="padding: 5px; border: 1px solid black; text-align: right;"
-                            >
+                            style="padding: 5px; border: 1px solid black; text-align: right;"
+                        >
                                 <t
-                                    t-out="format_amount(inv.amount_untaxed * (inv.move_type == 'out_refund' and -1 or 1), inv.currency_id)"
-                                />
+                                t-out="format_amount(inv.amount_untaxed * (inv.move_type == 'out_refund' and -1 or 1), inv.currency_id)"
+                            />
                             </td>
                             <td
-                                style="padding: 5px; border: 1px solid black; text-align: right;"
-                            >
+                            style="padding: 5px; border: 1px solid black; text-align: right;"
+                        >
                                 <t
-                                    t-out="format_amount(inv.amount_total * (inv.move_type == 'out_refund' and -1 or 1), inv.currency_id)"
-                                />
+                                t-out="format_amount(inv.amount_total * (inv.move_type == 'out_refund' and -1 or 1), inv.currency_id)"
+                            />
                             </td>
                             <td
-                                style="padding: 5px; border: 1px solid black; text-align: right;"
-                            >
+                            style="padding: 5px; border: 1px solid black; text-align: right;"
+                        >
                                 <t
-                                    t-out="format_amount(inv.amount_residual * (inv.move_type == 'out_refund' and -1 or 1), inv.currency_id)"
-                                />
+                                t-out="format_amount(inv.amount_residual * (inv.move_type == 'out_refund' and -1 or 1), inv.currency_id)"
+                            />
                             </td>
                             <td style="padding: 5px; border: 1px solid black;">
                                 <t t-out="inv.overdue_reminder_counter" />
                             </td>
                         </tr>
-                    </t>
-                    <t t-foreach="object.total_residual()" t-as="total_residual">
-                        <tr>
+                    <tr t-foreach="object.total_residual()" t-as="total_residual">
                             <td />
                             <td />
                             <td />
@@ -117,23 +113,22 @@
                             <td />
                             <td />
                             <td
-                                colspan="2"
-                                style="padding: 5px; border: 1px solid black; font-weight: bold; text-align: right;"
-                            >
+                            colspan="2"
+                            style="padding: 5px; border: 1px solid black; font-weight: bold; text-align: right;"
+                        >
                                 Total
                                 Residual in
                                 <t t-out="total_residual[0].name" />:
                             </td>
                             <td
-                                style="padding: 5px; border: 1px solid black; font-weight: bold; text-align: right;"
-                            >
+                            style="padding: 5px; border: 1px solid black; font-weight: bold; text-align: right;"
+                        >
                                 <t
-                                    t-out="format_amount(total_residual[1], total_residual[0])"
-                                />
+                                t-out="format_amount(total_residual[1], total_residual[0])"
+                            />
                             </td>
                             <td />
-                        </tr>
-                    </t>
+                    </tr>
                 </table>
 
                 <p

--- a/account_invoice_overdue_reminder/data/mail_template.xml
+++ b/account_invoice_overdue_reminder/data/mail_template.xml
@@ -56,11 +56,7 @@
                     <tr
                         t-foreach="object.invoice_ids.sorted(key='invoice_date')"
                         t-as="inv"
-                        style="background-color:
-                            % if inv.move_type == 'out_refund':
-                                LightGray
-                            % endif
-                        "
+                        t-att-style="'background-color: LightGray' if inv.move_type == 'out_refund' else None"
                     >
                             <td style="padding: 5px; border: 1px solid black;">
                                 <t t-out="inv.name" />


### PR DESCRIPTION
when editing the template with odoo's built-in wysiwig-editor, it will pull the two loops above the `<table />` node, as in

```xml
<t t-foreach="object.invoice_ids.sorted(key='invoice_date')" t-as="inv" />
<t t-foreach="object.total_residual()" t-as="total_residual" />
<table>
...
```

which renders the template basically defunct. Instead of teaching customers not to edit this template specifically (the editor works as expected when the qweb attributes live on structural nodes), I suggest to change the template such that it survives editing.

I very much disagree with what prettier did here, but that's what it did.