### PR TITLE
[18.0][FIX] account_invoice_overdue_reminder: skip company-dependent conversion when ir_property table is already gone

### DIFF
--- a/account_invoice_overdue_reminder/migrations/18.0.1.0.0/post-migration.py
+++ b/account_invoice_overdue_reminder/migrations/18.0.1.0.0/post-migration.py
@@ -5,4 +5,8 @@ from openupgradelib import openupgrade, openupgrade_180
 
 @openupgrade.migrate()
 def migrate(env, version):
+    if not openupgrade.table_exists(env.cr, "ir_property"):
+        # The database may have been already touched by Odoo's
+        # official migration scripts
+        return
     openupgrade_180.convert_company_dependent(env, "res.partner", "no_overdue_reminder")


### PR DESCRIPTION
Skip the company-dependent conversion when the ir_property table no longer exists, scripts from Odoo's official channels (like upgrade.odoo.com or odoo.sh) may already have migrated the table.