### PR TITLE
[18.0][FIX] account_financial_risk: Freeze time and match the module's own date reference in tests

### DIFF
--- a/account_financial_risk/tests/test_account_financial_risk.py
+++ b/account_financial_risk/tests/test_account_financial_risk.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 from odoo import Command, fields
 from odoo.exceptions import UserError
@@ -9,6 +10,7 @@ from odoo.exceptions import UserError
 from odoo.addons.base.tests.common import BaseCommon
 
 
+@freeze_time("2024-01-15 12:00:00")
 class TestPartnerFinancialRisk(BaseCommon):
     @classmethod
     def setUpClass(cls):
@@ -104,6 +106,13 @@ class TestPartnerFinancialRisk(BaseCommon):
             )
         )
         cls.env.user.lang = False
+        # Use the same "today" reference _max_risk_date_due() itself
+        # compares against (context_today(), timezone-aware) rather than
+        # the naive Date.today() - with time frozen above this doesn't
+        # change which day either resolves to, but it keeps the test
+        # exercising the exact same date computation the module uses
+        # instead of one that merely happens to agree with it right now.
+        cls.today = fields.Date.context_today(cls.env.user)
 
     def test_invoices(self):
         self.partner.risk_invoice_draft_include = True
@@ -134,7 +143,7 @@ class TestPartnerFinancialRisk(BaseCommon):
         unrisk_partners = self.partner.search([("risk_exception", "=", False)])
         self.assertIn(self.partner, unrisk_partners)
         self.partner.risk_invoice_open_limit = 300.0
-        invoice2.invoice_date_due = fields.Date.today()
+        invoice2.invoice_date_due = self.today
         wiz_dic = invoice2.action_post()
         wiz = self.env[wiz_dic["res_model"]].browse(wiz_dic["res_id"])
         self.assertEqual(
@@ -152,7 +161,7 @@ class TestPartnerFinancialRisk(BaseCommon):
         self.assertAlmostEqual(self.partner.risk_invoice_open, 0.0)
         wiz.button_continue()
         # HACK: Force the maturity date for not having an error here
-        invoice2.line_ids.write({"date_maturity": fields.Date.today()})
+        invoice2.line_ids.write({"date_maturity": self.today})
         self.assertAlmostEqual(self.partner.risk_invoice_open, 550.0)
         self.assertTrue(self.partner.risk_allow_edit)
 
@@ -163,7 +172,7 @@ class TestPartnerFinancialRisk(BaseCommon):
             .create(
                 {
                     "journal_id": self.journal_sale.id,
-                    "date": fields.Date.today(),
+                    "date": self.today,
                     "line_ids": [
                         Command.create(
                             {
@@ -191,7 +200,7 @@ class TestPartnerFinancialRisk(BaseCommon):
         line.date_maturity = "2017-01-01"
         self.assertAlmostEqual(self.partner.risk_account_amount, 0.0)
         self.assertAlmostEqual(self.partner.risk_account_amount_unpaid, 100.0)
-        line.date_maturity = fields.Date.today() - relativedelta(days=2)
+        line.date_maturity = self.today - relativedelta(days=2)
         self.assertAlmostEqual(self.partner.risk_account_amount, 0.0)
         self.assertAlmostEqual(self.partner.risk_account_amount_unpaid, 100.0)
         line.company_id.invoice_unpaid_margin = 3


### PR DESCRIPTION
_max_risk_date_due() computes the "today" boundary with fields.Date.context_today() (timezone-aware: this env's admin user defaults to Europe/Brussels), while the tests date-stamp their records with the naive fields.Date.today(). Whenever the real wall-clock instant a test runs at falls within the user's timezone offset window around midnight UTC, the two disagree by a day, pushing a record dated "today" out of the "open" (not yet due) bucket the assertions expect it in - reproduced 2026-09-09 close to midnight UTC, and confirmed reproducible on demand by freezing at an unsafe instant (23:30 UTC) before settling on a safe one.

Two changes, both needed: freeze time at a fixed, safe instant (noon UTC, clear of any realistic timezone offset crossing a day boundary) with freezegun's @freeze_time, already used the same way throughout this codebase for date-dependent OCA tests, so the test's result no longer depends on real wall-clock time at all; and use
fields.Date.context_today(cls.env.user) instead of the naive fields.Date.today() for the test's own date references, so it exercises the exact same date computation _max_risk_date_due() itself uses rather than one that merely happens to agree with it under the current freeze.

@Tecnativa

ping @sergio-teruel @carlos-lopez-tecnativa @juancarlosonate-tecnativa @CarlosRoca13 